### PR TITLE
add more default files and containers and reflect those in the profile

### DIFF
--- a/solid/lib/Controller/PageController.php
+++ b/solid/lib/Controller/PageController.php
@@ -61,7 +61,25 @@ class PageController extends Controller {
 				'id' => $userId,
 				'displayName' => $user->getDisplayName(),
 				'profileUri'  => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.page.turtleProfile", array("userId" => $userId))) . "#me",
-				'friends' => $friends
+				'friends' => $friends,
+				'inbox' => 'storage/inbox/',
+				'preferences' => 'storage/settings/preferences.ttl',
+				'privateTypeIndex' => 'storage/settings/privateTypeIndex.ttl',
+				'publicTypeIndex' => 'storage/settings/publicTypeIndex.ttl',
+				'storage' => 'storage/',
+/*
+				'trustedApps' => array(
+					array(
+						'origin' => 'https://localhost:3002',
+						'grants' => array(
+							'http://www.w3.org/ns/auth/acl#Read',
+							'http://www.w3.org/ns/auth/acl#Write',
+							'http://www.w3.org/ns/auth/acl#Append',
+							'http://www.w3.org/ns/auth/acl#Control'
+						)
+					)
+				)
+*/
 			);
 			return $profile;
 		}

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -304,7 +304,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handleRequest($userId, $path) {
 		$this->rawRequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals($_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
@@ -342,7 +341,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handleGet($userId, $path) {	
 		return $this->handleRequest($userId, $path);
@@ -352,7 +350,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handlePost($userId, $path) {
 		return $this->handleRequest($userId, $path);
@@ -361,7 +358,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handlePut() { // $userId, $path) {
 		// FIXME: Adding the correct variables in the function name will make nextcloud
@@ -381,7 +377,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handleDelete($userId, $path) {
 		return $this->handleRequest($userId, $path);
@@ -390,7 +385,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handleHead($userId, $path) {
 		return $this->handleRequest($userId, $path);
@@ -399,7 +393,6 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @CORS
 	 */
 	public function handlePatch($userId, $path) {
 		return $this->handleRequest($userId, $path);

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -289,6 +289,18 @@ EOF;
 		if (!$this->filesystem->has("/settings")) {
 			$this->filesystem->createDir("/settings");
 		}
+		if (!$this->filesystem->has("/settings/privateTypeIndex.ttl")) {
+			$privateTypeIndex = $this->generateDefaultPrivateTypeIndex();
+			$this->filesystem->write("/settings/privateTypeIndex.ttl", $privateTypeIndex);
+		}
+		if (!$this->filesystem->has("/settings/publicTypeIndex.ttl")) {
+			$publicTypeIndex = $this->generateDefaultPublicTypeIndex();
+			$this->filesystem->write("/settings/publicTypeIndex.ttl", $publicTypeIndex);
+		}
+		if (!$this->filesystem->has("/settings/preferences.ttl")) {
+			$preferences = $this->generateDefaultPreferences($userId);
+			$this->filesystem->write("/settings/preferences.ttl", $preferences);
+		}
 		if (!$this->filesystem->has("/public")) {
 			$this->filesystem->createDir("/public");
 		}

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -126,6 +126,13 @@ class StorageController extends Controller {
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
+# The homepage is readable by the public
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo </>;
+	acl:mode acl:Read.
+
 # The owner has full access to every resource in their pod.
 # Other agents have no access rights,
 # unless specifically authorized in other .acl resources.

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -329,7 +329,11 @@ EOF;
 			return $this->respond($response);
 		}
 		if (!$this->WAC->isAllowed($request, $webId)) {
-			$response = $this->resourceServer->getResponse()->withStatus(403, "Access denied");
+			$response = $this->resourceServer->getResponse()
+			->withStatus(403, "Access denied")
+            ->withHeader('Access-Control-Allow-Origin', '*')
+            ->withHeader('Access-Control-Allow-Credentials','true')
+            ->withHeader('Access-Control-Allow-Headers', 'Accept');
 			return $this->respond($response);
 		}
 		$response = $this->resourceServer->respondToRequest($request);	
@@ -404,11 +408,6 @@ EOF;
 		$headers = $response->getHeaders();
 
 		$body = $response->getBody()->getContents();
-		if ($statusCode > 399) {
-			$reason = $response->getReasonPhrase();
-			$result = new JSONResponse($reason, $statusCode);
-			return $result;
-		}
 
 		$result = new PlainResponse($body); // FIXME: we need a way to just return a plain response;
 

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -130,7 +130,7 @@ class StorageController extends Controller {
 <#public>
     a acl:Authorization;
     acl:agentClass foaf:Agent;
-    acl:accessTo </>;
+    acl:accessTo <./>;
 	acl:mode acl:Read.
 
 # The owner has full access to every resource in their pod.
@@ -140,9 +140,9 @@ class StorageController extends Controller {
 	a acl:Authorization;
 	acl:agent <{user-profile-uri}>;
 	# Set the access to the root storage folder itself
-	acl:accessTo </>;
+	acl:accessTo <./>;
 	# All resources will inherit this authorization, by default
-	acl:default </>;
+	acl:default <./>;
 	# The owner has all of the access modes allowed
 	acl:mode
 		acl:Read, acl:Write, acl:Control.
@@ -304,6 +304,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handleRequest($userId, $path) {
 		$this->rawRequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals($_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
@@ -341,6 +342,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handleGet($userId, $path) {	
 		return $this->handleRequest($userId, $path);
@@ -350,6 +352,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handlePost($userId, $path) {
 		return $this->handleRequest($userId, $path);
@@ -358,6 +361,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handlePut() { // $userId, $path) {
 		// FIXME: Adding the correct variables in the function name will make nextcloud
@@ -377,6 +381,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handleDelete($userId, $path) {
 		return $this->handleRequest($userId, $path);
@@ -385,6 +390,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handleHead($userId, $path) {
 		return $this->handleRequest($userId, $path);
@@ -393,6 +399,7 @@ EOF;
 	 * @PublicPage
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @CORS
 	 */
 	public function handlePatch($userId, $path) {
 		return $this->handleRequest($userId, $path);

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -146,7 +146,7 @@ EOF;
 		return $defaultAcl;
 	}
 
-	private function generatePublicAppendAcl() {
+	private function generatePublicAppendAcl($userId) {
 		$publicAppendAcl = <<< EOF
 # Inbox ACL resource for the user account
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
@@ -177,7 +177,7 @@ EOF;
 		return $publicAppendAcl;
 	}
 
-	private function generatePublicReadAcl() {
+	private function generatePublicReadAcl($userId) {
 		$publicReadAcl = <<< EOF
 # Inbox ACL resource for the user account
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
@@ -276,7 +276,7 @@ EOF;
 			$this->filesystem->createDir("/inbox");
 		}
 		if (!$this->filesystem->has("/inbox/.acl")) {
-			$inboxAcl = $this->generatePublicAppendAcl();
+			$inboxAcl = $this->generatePublicAppendAcl($userId);
 			$this->filesystem->write("/inbox/.acl", $inboxAcl);
 		}
 		if (!$this->filesystem->has("/settings")) {
@@ -286,7 +286,7 @@ EOF;
 			$this->filesystem->createDir("/public");
 		}
 		if (!$this->filesystem->has("/public/.acl")) {
-			$publicAcl = $this->generatePublicReadAcl();
+			$publicAcl = $this->generatePublicReadAcl($userId);
 			$this->filesystem->write("/public/.acl", $publicAcl);
 		}
 		if (!$this->filesystem->has("/private")) {
@@ -299,10 +299,10 @@ EOF;
 	 * @NoCSRFRequired
 	 */
 	public function handleRequest($userId, $path) {
-		$this->initializeStorage($userId);
-
 		$this->rawRequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals($_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
 		$this->response = new \Laminas\Diactoros\Response();
+
+		$this->initializeStorage($userId);
 
 		$this->resourceServer = new ResourceServer($this->filesystem, $this->response);		
 		$this->WAC = new WAC($this->filesystem);

--- a/solid/templates/profile/turtle.php
+++ b/solid/templates/profile/turtle.php
@@ -7,9 +7,9 @@
 @prefix schem: <http://schema.org/>.
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix ldp: <http://www.w3.org/ns/ldp#>.
-@prefix inbox: </inbox/>.
+@prefix inbox: <<?php p($_['inbox']); ?>>.
 @prefix sp: <http://www.w3.org/ns/pim/space#>.
-@prefix ser: <storage/>.
+@prefix ser: <<?php p($_['storage']); ?>>.
 
 pro:turtle a foaf:PersonalProfileDocument; foaf:maker :me; foaf:primaryTopic :me.
 
@@ -21,11 +21,11 @@ pro:turtle a foaf:PersonalProfileDocument; foaf:maker :me; foaf:primaryTopic :me
                 acl:origin <http://localhost:3002>
             ];
     ldp:inbox inbox:;
-    sp:preferencesFile </settings/prefs.ttl>;
+    sp:preferencesFile <<?php p($_['preferences']); ?>>;
     sp:storage ser:;
     solid:account ser:;
-    solid:privateTypeIndex </settings/privateTypeIndex.ttl>;
-    solid:publicTypeIndex </settings/publicTypeIndex.ttl>;
+    solid:privateTypeIndex <<?php p($_['privateTypeIndex']); ?>>;
+    solid:publicTypeIndex <<?php p($_['publicTypeIndex']); ?>>;
 <?php
 foreach ($_['friends'] as $k => $v) {
 ?>

--- a/solid/templates/profile/turtle.php
+++ b/solid/templates/profile/turtle.php
@@ -15,11 +15,6 @@ pro:turtle a foaf:PersonalProfileDocument; foaf:maker :me; foaf:primaryTopic :me
 
 :me
     a schem:Person, foaf:Person;
-    acl:trustedApp
-            [
-                acl:mode acl:Append, acl:Control, acl:Read, acl:Write;
-                acl:origin <http://localhost:3002>
-            ];
     ldp:inbox inbox:;
     sp:preferencesFile <<?php p($_['preferences']); ?>>;
     sp:storage ser:;

--- a/solid/templates/turtle-profile.php
+++ b/solid/templates/turtle-profile.php
@@ -1,1 +1,1 @@
-<?php print_unescaped($this->inc('settings/preferences')); ?>
+<?php print_unescaped($this->inc('profile/turtle')); ?>

--- a/solid/templates/turtle-profile.php
+++ b/solid/templates/turtle-profile.php
@@ -1,2 +1,1 @@
-			<?php print_unescaped($this->inc('profile/turtle')); ?>
-
+<?php print_unescaped($this->inc('settings/preferences')); ?>


### PR DESCRIPTION
This change adds more default content in the user's storage pod:
/inbox/ (with public append)
/public/ (with public read)
/settings/privateTypeIndex.ttl
/settings/publicTypeIndex.ttl
/settings/preferences.ttl

The created paths are linked in the user's profile.