### PR TITLE
Fixes for controllers

### DIFF
--- a/solid/lib/Controller/AppController.php
+++ b/solid/lib/Controller/AppController.php
@@ -34,7 +34,7 @@ class AppController extends Controller {
 		$userApps = [];
 		if ($this->userManager->userExists($userId)) {
             $allowedClients = $this->config->getAllowedClients($userId);
-			foreach ($userClients as $clientId) {
+			foreach ($allowedClients as $clientId) {
 				$registration = $this->config->getClientRegistration($clientId);
 				$userApps[] = $registration['client_name'];
 			}
@@ -52,7 +52,7 @@ class AppController extends Controller {
 		foreach ($appsList as $key => $app) {
 			$parsedOrigin = parse_url($app['launchUrl']);
 			$origin = $parsedOrigin['host'];
-			if (in_array($userApps, $origin)) {
+			if (in_array($origin, $userApps, true)) {
 				$appsList[$key]['registered'] = 1;
 			} else {
 				$appsList[$key]['registered'] = 0;

--- a/solid/lib/Controller/PageController.php
+++ b/solid/lib/Controller/PageController.php
@@ -46,16 +46,18 @@ class PageController extends Controller {
 	private function getUserProfile($userId) {
 		if ($this->userManager->userExists($userId)) {
 			$user = $this->userManager->get($userId);
-			$profile = array(
-				'id' => $userId,
-				'displayName' => $user->getDisplayName(),
-				'profileUri'  => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.profile.handleGet", array("userId" => $userId, "path" => "/card"))) . "#me",
-				'solidNavigation'  => array(
-					"profile" => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.page.profile", array("userId" => $this->userId))),
-					"launcher" => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.app.appLauncher", array())),
-				)
-			);
-			return $profile;
+			if ($user !== null) {
+				$profile = array(
+					'id' => $userId,
+					'displayName' => $user->getDisplayName(),
+					'profileUri'  => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.profile.handleGet", array("userId" => $userId, "path" => "/card"))) . "#me",
+					'solidNavigation'  => array(
+						"profile" => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.page.profile", array("userId" => $this->userId))),
+						"launcher" => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.app.appLauncher", array())),
+					)
+				);
+				return $profile;
+			}
 		}
 		return false;
 	}

--- a/solid/lib/Controller/ProfileController.php
+++ b/solid/lib/Controller/ProfileController.php
@@ -267,18 +267,20 @@ EOF;
 				  }
 				}
 			}
-			$profile = array(
-				'id' => $userId,
-				'displayName' => $user->getDisplayName(),
-				'profileUri'  => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.profile.handleGet", array("userId" => $userId, "path" => "/card"))) . "#me",
-				'friends' => $friends,
-				'inbox' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/inbox/"))),
-				'preferences' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/preferences.ttl"))),
-				'privateTypeIndex' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/privateTypeIndex.ttl"))),
-				'publicTypeIndex' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/publicTypeIndex.ttl"))),
-				'storage' => $this->getStorageUrl($userId)
-			);
-			return $profile;
+			if ($user !== null) {
+				$profile = array(
+					'id' => $userId,
+					'displayName' => $user->getDisplayName(),
+					'profileUri'  => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.profile.handleGet", array("userId" => $userId, "path" => "/card"))) . "#me",
+					'friends' => $friends,
+					'inbox' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/inbox/"))),
+					'preferences' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/preferences.ttl"))),
+					'privateTypeIndex' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/privateTypeIndex.ttl"))),
+					'publicTypeIndex' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/publicTypeIndex.ttl"))),
+					'storage' => $this->getStorageUrl($userId)
+				);
+				return $profile;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
Fix various (possible) bugs in Controllers:

- Add null checks
- Remove non-existing variables
- Fix typo in classname
- Make null return explicit
- Fix bug caused by incorrect needle/haystack in AppController.
- Fix bug caused by non-existing variable being used in AppController.

I want this merged post-haste, so we can deploy a release to the NC app store, in order to prevent further issues being opened for the same bug... but currently the build is failing on the composer install. The same fix as done for the standalone PHP also needs to be applied here first (see https://github.com/pdsinterop/php-solid-server/commit/6a485773cfc5c51f77ff18d93a72ff99c0c79a45).