### PR TITLE
Move CORS config from webserver config to middleware

### DIFF
--- a/init-live.sh
+++ b/init-live.sh
@@ -3,7 +3,6 @@ export PHP_MEMORY_LIMIT="512M"
 php console.php maintenance:install --admin-user admin --admin-pass $MARIADB_ROOT_PASSWORD --database "mysql" --database-name "nextcloud" --database-user "root" --database-pass "$MARIADB_ROOT_PASSWORD" --database-host "127.0.0.1"
 php console.php status
 php console.php app:enable solid
-sed -i '96 i\  RewriteRule ^\\.well-known/openid-configuration /apps/solid/openid [R=302,L]' /var/www/html/.htaccess
 sed -i "25 i\    1 => 'server'," /var/www/html/config/config.php
 sed -i "26 i\    2 => 'nextcloud.local'," /var/www/html/config/config.php
 sed -i "27 i\    3 => 'thirdparty'," /var/www/html/config/config.php

--- a/site.conf
+++ b/site.conf
@@ -6,14 +6,4 @@
     SSLEngine on
     SSLCertificateFile "/tls/server.cert"
     SSLCertificateKeyFile "/tls/server.key"
-
-    Header always set Access-Control-Allow-Origin *
-    SetEnvIf Origin "(.+)" AccessControlAllowOrigin=$0
-    Header always set Access-Control-Allow-Origin %{AccessControlAllowOrigin}e env=AccessControlAllowOrigin
-
-    Header always set Access-Control-Allow-Credentials true
-    Header always set Access-Control-Allow-Headers "*, allow, accept, authorization, content-type, dpop, slug"
-    Header always set Access-Control-Allow-Methods "GET, PUT, POST, OPTIONS, DELETE, PATCH"
-    Header always set Accept-Patch: text/n3
-    Header always set Access-Control-Expose-Headers "Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via"
 </VirtualHost>

--- a/solid/lib/AppInfo/Application.php
+++ b/solid/lib/AppInfo/Application.php
@@ -24,49 +24,49 @@ use OCP\Settings\IManager;
 use OCP\Util;
 
 class Application extends App implements IBootstrap {
-	public const APP_ID = 'solid';
+    public const APP_ID = 'solid';
 
-	/**
-	 * @param array $urlParams
-	 */
-	public function __construct(array $urlParams = []) {
-		parent::__construct(self::APP_ID, $urlParams);
+    /**
+     * @param array $urlParams
+     */
+    public function __construct(array $urlParams = []) {
+        parent::__construct(self::APP_ID, $urlParams);
 
-                $container = $this->getContainer();
+        $container = $this->getContainer();
 
-                $container->registerService(SolidCorsMiddleware::class, function($c): SolidCorsMiddleware{
-                        return new SolidCorsMiddleware(
-                                $c->get(IRequest::class)
-                        );
-                });
+        $container->registerService(SolidCorsMiddleware::class, function($c): SolidCorsMiddleware {
+            return new SolidCorsMiddleware(
+                $c->get(IRequest::class)
+            );
+        });
 
-                // executed in the order that it is registered
-                $container->registerMiddleware(SolidCorsMiddleware::class);
-        }
+        // executed in the order that it is registered
+        $container->registerMiddleware(SolidCorsMiddleware::class);
+    }
 
-	public function register(IRegistrationContext $context): void {
-		$context->registerWellKnownHandler(\OCA\Solid\WellKnown\OpenIdConfigurationHandler::class);
+    public function register(IRegistrationContext $context): void {
+        $context->registerWellKnownHandler(\OCA\Solid\WellKnown\OpenIdConfigurationHandler::class);
 
-		/**
-		 * Core class wrappers
-		 */
+        /**
+         * Core class wrappers
+         */
 
-		$context->registerService('UserService', function($c) {
-			return new \OCA\Solid\Service\UserService(
-				$c->query('UserSession')
-			);
-		});
-		$context->registerService('UserSession', function($c) {
-			return $c->query('ServerContainer')->getUserSession();
-		});
+        $context->registerService('UserService', function($c) {
+            return new \OCA\Solid\Service\UserService(
+                $c->query('UserSession')
+            );
+        });
+        $context->registerService('UserSession', function($c) {
+            return $c->query('ServerContainer')->getUserSession();
+        });
 
-		// currently logged in user, userId can be gotten by calling the
-		// getUID() method on it
-		$context->registerService('User', function($c) {
-			return $c->query('UserSession')->getUser();
-		});
-	}
+        // currently logged in user, userId can be gotten by calling the
+        // getUID() method on it
+        $context->registerService('User', function($c) {
+            return $c->query('UserSession')->getUser();
+        });
+    }
 
-	public function boot(IBootContext $context): void {
-	}
+    public function boot(IBootContext $context): void {
+    }
 }

--- a/solid/lib/AppInfo/Application.php
+++ b/solid/lib/AppInfo/Application.php
@@ -31,7 +31,15 @@ class Application extends App implements IBootstrap {
 	 */
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);
-	}
+                $container->registerService(SolidCorsMiddleware::class, function(IServerContainer $c): SolidCorsMiddleware{
+                        return new SolidCorsMiddleware(
+                                $c->get(IRequest::class)
+                        );
+                });
+
+                // executed in the order that it is registered
+                $container->registerMiddleware(SolidCorsMiddleware::class);
+        }
 
 	public function register(IRegistrationContext $context): void {
 		$context->registerWellKnownHandler(\OCA\Solid\WellKnown\OpenIdConfigurationHandler::class);
@@ -54,18 +62,6 @@ class Application extends App implements IBootstrap {
 		$context->registerService('User', function($c) {
 			return $c->query('UserSession')->getUser();
 		});
-
-                /**
-                 * Middleware
-                 */
-                $context->registerService('SolidCorsMiddleware', function($c) {
-                        return new SolidCorsMiddleware(
-                            $c->get(IRequest::class)
-                        );
-                });
-
-                // executed in the order that it is registered
-                $context->registerMiddleware('SolidCorsMiddleware');
 	}
 
 	public function boot(IBootContext $context): void {

--- a/solid/lib/AppInfo/Application.php
+++ b/solid/lib/AppInfo/Application.php
@@ -31,7 +31,10 @@ class Application extends App implements IBootstrap {
 	 */
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);
-                $container->registerService(SolidCorsMiddleware::class, function(IServerContainer $c): SolidCorsMiddleware{
+
+                $container = $this->getContainer();
+
+                $container->registerService(SolidCorsMiddleware::class, function($c): SolidCorsMiddleware{
                         return new SolidCorsMiddleware(
                                 $c->get(IRequest::class)
                         );

--- a/solid/lib/AppInfo/Application.php
+++ b/solid/lib/AppInfo/Application.php
@@ -11,6 +11,7 @@ use OC\Server;
 
 use OCA\Solid\Service\UserService;
 use OCA\Solid\WellKnown\OpenIdConfigurationHandler;
+use OCA\Solid\Middleware\SolidCorsMiddleware;
 
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -53,6 +54,12 @@ class Application extends App implements IBootstrap {
 		$context->registerService('User', function($c) {
 			return $c->query('UserSession')->getUser();
 		});
+
+		$context->registerService('SolidCorsMiddleware', function($c) {
+		        return new SolidCorsMiddleware();
+		});
+
+		$context->registerMiddleware('SolidCorsMiddleware');
 	}
 
 	public function boot(IBootContext $context): void {

--- a/solid/lib/AppInfo/Application.php
+++ b/solid/lib/AppInfo/Application.php
@@ -58,14 +58,14 @@ class Application extends App implements IBootstrap {
                 /**
                  * Middleware
                  */
-                $container->registerService(SolidCorsMiddleware::class, function(IServerContainer $c): SolidCorsMiddleware{
+                $context->registerService('SolidCorsMiddleware', function($c) {
                         return new SolidCorsMiddleware(
                             $c->get(IRequest::class)
                         );
                 });
 
                 // executed in the order that it is registered
-                $container->registerMiddleware(SolidCorsMiddleware::class);
+                $context->registerMiddleware('SolidCorsMiddleware');
 	}
 
 	public function boot(IBootContext $context): void {

--- a/solid/lib/AppInfo/Application.php
+++ b/solid/lib/AppInfo/Application.php
@@ -55,11 +55,17 @@ class Application extends App implements IBootstrap {
 			return $c->query('UserSession')->getUser();
 		});
 
-		$context->registerService('SolidCorsMiddleware', function($c) {
-		        return new SolidCorsMiddleware();
-		});
+                /**
+                 * Middleware
+                 */
+                $container->registerService(SolidCorsMiddleware::class, function(IServerContainer $c): SolidCorsMiddleware{
+                        return new SolidCorsMiddleware(
+                            $c->get(IRequest::class)
+                        );
+                });
 
-		$context->registerMiddleware('SolidCorsMiddleware');
+                // executed in the order that it is registered
+                $container->registerMiddleware(SolidCorsMiddleware::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/solid/lib/Middleware/SolidCorsMiddleware.php
+++ b/solid/lib/Middleware/SolidCorsMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+    namespace OCA\Solid\Middleware;
+
+    use \OCP\AppFramework\Middleware;
+    use \OCP\IRequest;
+
+    class SolidCorsMiddleware extends Middleware {
+        public function afterController($controller, $methodName, IResponse $response) {
+            $corsMethods="GET, PUT, POST, OPTIONS, DELETE, PATCH";
+            $corsAllowedHeaders="*, allow, accept, authorization, content-type, dpop, slug";
+            $corsMaxAge=1728000;
+            $corsExposeHeaders="Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via";
+            $corsAllowCredentials=true;
+            
+            $response->addHeader('Access-Control-Allow-Origin', $corsAllowOrigin);
+            $response->addHeader('Access-Control-Allow-Methods', $corsMethods);
+            $response->addHeader('Access-Control-Allow-Headers', $corsAllowedHeaders);
+            $response->addHeader('Access-Control-Max-Age', (string)$corsMaxAge);
+            $response->addHeader('Access-Control-Allow-Credentials', $corsAllowCredentials);
+            $response->addHeader('Access-Control-Expose-Headers', $corsExposeHeaders);
+            $response->addHeader('Accept-Patch', 'text/n3');
+        }
+    }

--- a/solid/lib/Middleware/SolidCorsMiddleware.php
+++ b/solid/lib/Middleware/SolidCorsMiddleware.php
@@ -1,17 +1,31 @@
 <?php
     namespace OCA\Solid\Middleware;
 
-    use \OCP\AppFramework\Middleware;
-    use \OCP\IRequest;
+    use OCP\AppFramework\Middleware;
+    use OCP\AppFramework\Http\Response;
+    use OCP\IResponse;
+    use OCP\IRequest;
 
     class SolidCorsMiddleware extends Middleware {
-        public function afterController($controller, $methodName, IResponse $response) {
+        private $request;
+
+        public function __construct(IRequest $request) {
+            $this->request = $request;
+        }
+
+        public function afterController($controller, $methodName, Response $response) {
             $corsMethods="GET, PUT, POST, OPTIONS, DELETE, PATCH";
             $corsAllowedHeaders="*, allow, accept, authorization, content-type, dpop, slug";
             $corsMaxAge=1728000;
             $corsExposeHeaders="Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via";
             $corsAllowCredentials=true;
-            
+
+            if (isset($this->request->server['HTTP_ORIGIN'])) {
+                $corsAllowOrigin = $this->request->server['HTTP_ORIGIN'];
+            } else {
+                $corsAllowOrigin = '*';
+            }
+
             $response->addHeader('Access-Control-Allow-Origin', $corsAllowOrigin);
             $response->addHeader('Access-Control-Allow-Methods', $corsMethods);
             $response->addHeader('Access-Control-Allow-Headers', $corsAllowedHeaders);

--- a/solid/lib/Middleware/SolidCorsMiddleware.php
+++ b/solid/lib/Middleware/SolidCorsMiddleware.php
@@ -16,9 +16,9 @@
         public function afterController($controller, $methodName, Response $response) {
             $corsMethods="GET, PUT, POST, OPTIONS, DELETE, PATCH";
             $corsAllowedHeaders="*, allow, accept, authorization, content-type, dpop, slug";
-            $corsMaxAge=1728000;
+            $corsMaxAge="1728000";
             $corsExposeHeaders="Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via";
-            $corsAllowCredentials=true;
+            $corsAllowCredentials="true";
 
             if (isset($this->request->server['HTTP_ORIGIN'])) {
                 $corsAllowOrigin = $this->request->server['HTTP_ORIGIN'];
@@ -29,9 +29,11 @@
             $response->addHeader('Access-Control-Allow-Origin', $corsAllowOrigin);
             $response->addHeader('Access-Control-Allow-Methods', $corsMethods);
             $response->addHeader('Access-Control-Allow-Headers', $corsAllowedHeaders);
-            $response->addHeader('Access-Control-Max-Age', (string)$corsMaxAge);
+            $response->addHeader('Access-Control-Max-Age', $corsMaxAge);
             $response->addHeader('Access-Control-Allow-Credentials', $corsAllowCredentials);
             $response->addHeader('Access-Control-Expose-Headers', $corsExposeHeaders);
             $response->addHeader('Accept-Patch', 'text/n3');
+
+            return $response;
         }
     }


### PR DESCRIPTION
This PR adds middleware to the solid app to add CORS headers to all that is running the solid app, removing the need for CORS headers in the apache or webserver configuration. This means we should be able to install without modifications to the webserver configuration any longer.