### PR TITLE
 Add support for a JWT "jti" value to prevent replay attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       # Run the Solid test-suite
       - name: Run the Solid test suite
-      # Until the test-suite has been fixed, allow the tests to fail.
+        # Until the test-suite has been fixed, allow the tests to fail.
         # See: https://github.com/pdsinterop/solid-nextcloud/issues/69
         continue-on-error: true
         shell: 'script -q -e -c "bash {0}"'

--- a/build/phpcs.xml.dist
+++ b/build/phpcs.xml.dist
@@ -18,7 +18,7 @@
     <exclude-pattern>*/vendor/*|*/build/*</exclude-pattern>
 
     <rule ref="PHPCompatibility"/>
-    <config name="testVersion" value="7.3-"/>
+    <config name="testVersion" value="8.0-"/>
 
     <!-- Include the whole PSR-12 standard -->
     <rule ref="PSR12">

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -22,14 +22,16 @@
     ],
     "require": {
         "php": "^8.0",
+        "ext-dom": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "ext-openssl": "*",
         "easyrdf/easyrdf": "^1.1.1",
         "laminas/laminas-diactoros": "^2.8",
         "lcobucci/jwt": "^4.1",
         "pdsinterop/flysystem-nextcloud":"^0.2",
         "pdsinterop/flysystem-rdf": "^0.5",
-        "pdsinterop/solid-auth": "^0.7",
+        "pdsinterop/solid-auth": "^0.8",
         "pdsinterop/solid-crud": "^0.6",
         "psr/log" : "^1.1"
     },

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -29,11 +29,11 @@
         "easyrdf/easyrdf": "^1.1.1",
         "laminas/laminas-diactoros": "^2.8",
         "lcobucci/jwt": "^4.1",
-        "pdsinterop/flysystem-nextcloud":"^0.2",
+        "pdsinterop/flysystem-nextcloud": "^0.2",
         "pdsinterop/flysystem-rdf": "^0.5",
-        "pdsinterop/solid-auth": "^0.8.2",
+        "pdsinterop/solid-auth": "^0.9",
         "pdsinterop/solid-crud": "^0.6",
-        "psr/log" : "^1.1"
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "doctrine/dbal": "*",

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -31,7 +31,7 @@
         "lcobucci/jwt": "^4.1",
         "pdsinterop/flysystem-nextcloud": "^0.2",
         "pdsinterop/flysystem-rdf": "^0.5",
-        "pdsinterop/solid-auth": "^0.10",
+        "pdsinterop/solid-auth": "v0.10.1",
         "pdsinterop/solid-crud": "^0.6",
         "psr/log": "^1.1"
     },

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -31,7 +31,7 @@
         "lcobucci/jwt": "^4.1",
         "pdsinterop/flysystem-nextcloud":"^0.2",
         "pdsinterop/flysystem-rdf": "^0.5",
-        "pdsinterop/solid-auth": "^0.8.1",
+        "pdsinterop/solid-auth": "^0.8.2",
         "pdsinterop/solid-crud": "^0.6",
         "psr/log" : "^1.1"
     },

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -36,6 +36,34 @@
         "psr/log" : "^1.1"
     },
     "require-dev": {
+        "doctrine/dbal": "*",
+        "nextcloud/server": "*",
         "phpunit/phpunit": "^8 || ^9"
-    }
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "nextcloud/server",
+                "version": "24.0.0",
+                "dist": {
+                    "url": "https://github.com/nextcloud/server/archive/refs/tags/v24.0.0.zip",
+                    "type": "zip"
+                },
+                "source": {
+                    "url": "https://github.com/nextcloud/server.git",
+                    "type": "git",
+                    "reference": "master"
+                },
+                "autoload": {
+                    "psr-4": {
+                        "": "lib/private/legacy",
+                        "OC\\": "lib/private",
+                        "OC\\Core\\": "core/",
+                        "OCP\\": "lib/public"
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -31,7 +31,7 @@
         "lcobucci/jwt": "^4.1",
         "pdsinterop/flysystem-nextcloud": "^0.2",
         "pdsinterop/flysystem-rdf": "^0.5",
-        "pdsinterop/solid-auth": "^0.9",
+        "pdsinterop/solid-auth": "^0.10",
         "pdsinterop/solid-crud": "^0.6",
         "psr/log": "^1.1"
     },

--- a/solid/composer.json
+++ b/solid/composer.json
@@ -31,7 +31,7 @@
         "lcobucci/jwt": "^4.1",
         "pdsinterop/flysystem-nextcloud":"^0.2",
         "pdsinterop/flysystem-rdf": "^0.5",
-        "pdsinterop/solid-auth": "^0.8",
+        "pdsinterop/solid-auth": "^0.8.1",
         "pdsinterop/solid-crud": "^0.6",
         "psr/log" : "^1.1"
     },

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "135df12c9b24674679159e63387ae129",
+    "content-hash": "12a2c4145b59310bde3d280fa2b453f9",
     "packages": [
         {
             "name": "arc/base",
@@ -1008,37 +1008,38 @@
         },
         {
             "name": "league/uri",
-            "version": "6.7.2",
+            "version": "6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "d3b50812dd51f3fbf176344cc2981db03d10fe06"
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/d3b50812dd51f3fbf176344cc2981db03d10fe06",
-                "reference": "d3b50812dd51f3fbf176344cc2981db03d10fe06",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "league/uri-interfaces": "^2.3",
-                "php": "^7.4 || ^8.0",
-                "psr/http-message": "^1.0"
+                "php": "^8.1",
+                "psr/http-message": "^1.0.1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.3.2",
-                "nyholm/psr7": "^1.5",
-                "php-http/psr7-integration-tests": "^1.1",
-                "phpstan/phpstan": "^1.2.0",
+                "friendsofphp/php-cs-fixer": "^v3.9.5",
+                "nyholm/psr7": "^1.5.1",
+                "php-http/psr7-integration-tests": "^1.1.1",
+                "phpbench/phpbench": "^1.2.6",
+                "phpstan/phpstan": "^1.8.5",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.1.0",
-                "phpunit/phpunit": "^9.5.10",
-                "psr/http-factory": "^1.0"
+                "phpstan/phpstan-phpunit": "^1.1.1",
+                "phpstan/phpstan-strict-rules": "^1.4.3",
+                "phpunit/phpunit": "^9.5.24",
+                "psr/http-factory": "^1.0.1"
             },
             "suggest": {
                 "ext-fileinfo": "Needed to create Data URI from a filepath",
@@ -1095,7 +1096,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri/issues",
-                "source": "https://github.com/thephpleague/uri/tree/6.7.2"
+                "source": "https://github.com/thephpleague/uri/tree/6.8.0"
             },
             "funding": [
                 {
@@ -1103,7 +1104,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-13T19:50:42+00:00"
+            "time": "2022-09-13T19:58:47+00:00"
         },
         {
             "name": "league/uri-interfaces",
@@ -1962,16 +1963,16 @@
         },
         {
             "name": "stella-maris/clock",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "source": {
                 "type": "git",
                 "url": "git@gitlab.com:stella-maris/clock.git",
-                "reference": "447879c53ca0b2a762cdbfba5e76ccf4deca9158"
+                "reference": "a94228dac03c9a8411198ce8c8dacbbe99c930c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=447879c53ca0b2a762cdbfba5e76ccf4deca9158",
-                "reference": "447879c53ca0b2a762cdbfba5e76ccf4deca9158",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=a94228dac03c9a8411198ce8c8dacbbe99c930c3",
+                "reference": "a94228dac03c9a8411198ce8c8dacbbe99c930c3",
                 "shasum": ""
             },
             "require": {
@@ -2001,7 +2002,7 @@
                 "point in time",
                 "psr20"
             ],
-            "time": "2022-08-05T07:21:25+00:00"
+            "time": "2022-09-27T15:03:11+00:00"
         },
         {
             "name": "textalk/websocket",
@@ -2131,6 +2132,344 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/cache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T20:07:39+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "a5a58773109c0abb13e658c8ccd92aeec8d07f9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/a5a58773109c0abb13e658c8ccd92aeec8d07f9e",
+                "reference": "a5a58773109c0abb13e658c8ccd92aeec8d07f9e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "10.0.0",
+                "jetbrains/phpstorm-stubs": "2022.2",
+                "phpstan/phpstan": "1.8.3",
+                "phpstan/phpstan-strict-rules": "^1.3",
+                "phpunit/phpunit": "9.5.24",
+                "psalm/plugin-phpunit": "0.17.0",
+                "squizlabs/php_codesniffer": "3.7.1",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/console": "^4.4|^5.4|^6.0",
+                "vimeo/psalm": "4.27.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-09-23T17:48:57+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5|^8.5|^9.5",
+                "psr/log": "^1|^2|^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+            },
+            "time": "2022-05-02T15:47:09+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "eb2ecf80e3093e8f3c2769ac838e27d8ede8e683"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/eb2ecf80e3093e8f3c2769ac838e27d8ede8e683",
+                "reference": "eb2ecf80e3093e8f3c2769ac838e27d8ede8e683",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "phpstan/phpstan": "~1.4.10 || ^1.5.4",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-27T22:18:11+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.1",
             "source": {
@@ -2258,6 +2597,28 @@
                 }
             ],
             "time": "2022-03-03T13:19:32+00:00"
+        },
+        {
+            "name": "nextcloud/server",
+            "version": "24.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nextcloud/server.git",
+                "reference": "master"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/nextcloud/server/archive/refs/tags/v24.0.0.zip"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "": "lib/private/legacy",
+                    "OC\\": "lib/private",
+                    "OC\\Core\\": "core/",
+                    "OCP\\": "lib/public"
+                }
+            }
         },
         {
             "name": "nikic/php-parser",
@@ -2746,16 +3107,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.24",
+            "version": "9.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
                 "shasum": ""
             },
             "require": {
@@ -2777,14 +3138,14 @@
                 "phpunit/php-timer": "^5.0.2",
                 "sebastian/cli-parser": "^1.0.1",
                 "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
+                "sebastian/comparator": "^4.0.8",
                 "sebastian/diff": "^4.0.3",
                 "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
+                "sebastian/exporter": "^4.0.5",
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.1",
+                "sebastian/type": "^3.2",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -2828,7 +3189,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
             },
             "funding": [
                 {
@@ -2838,9 +3199,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-08-30T07:42:16+00:00"
+            "time": "2022-09-25T03:44:45+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3870,5 +4235,5 @@
         "ext-openssl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12f2f0af65f30dd89c622c56c268f852",
+    "content-hash": "ab258d6208b4a89c140fb21224963a88",
     "packages": [
         {
             "name": "arc/base",
@@ -1486,16 +1486,16 @@
         },
         {
             "name": "pdsinterop/solid-auth",
-            "version": "v0.8.2",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdsinterop/php-solid-auth.git",
-                "reference": "fc3abfa1470eed949d1418e843c5a33255c6b178"
+                "reference": "ea830b64a62468eda6afdbc3fb15231036d32ef5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/fc3abfa1470eed949d1418e843c5a33255c6b178",
-                "reference": "fc3abfa1470eed949d1418e843c5a33255c6b178",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/ea830b64a62468eda6afdbc3fb15231036d32ef5",
+                "reference": "ea830b64a62468eda6afdbc3fb15231036d32ef5",
                 "shasum": ""
             },
             "require": {
@@ -1529,9 +1529,9 @@
             "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
             "support": {
                 "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.8.2"
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.9.0"
             },
-            "time": "2022-09-28T12:50:40+00:00"
+            "time": "2022-09-30T07:51:27+00:00"
         },
         {
             "name": "pdsinterop/solid-crud",

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "442305e84dea7a1af38ca3c380e2221d",
+    "content-hash": "df284f3fd32112c1d0a69574170e1388",
     "packages": [
         {
             "name": "arc/base",
@@ -1486,16 +1486,16 @@
         },
         {
             "name": "pdsinterop/solid-auth",
-            "version": "v0.10.0",
+            "version": "v0.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdsinterop/php-solid-auth.git",
-                "reference": "e5453e01792f9c3be8682c85b92615a0fc14eb0b"
+                "reference": "c33509edefdbc23b78d745bc4116e04a2b294ab3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/e5453e01792f9c3be8682c85b92615a0fc14eb0b",
-                "reference": "e5453e01792f9c3be8682c85b92615a0fc14eb0b",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/c33509edefdbc23b78d745bc4116e04a2b294ab3",
+                "reference": "c33509edefdbc23b78d745bc4116e04a2b294ab3",
                 "shasum": ""
             },
             "require": {
@@ -1529,9 +1529,9 @@
             "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
             "support": {
                 "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.10.0"
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.10.1"
             },
-            "time": "2022-09-30T11:29:01+00:00"
+            "time": "2022-09-30T12:16:20+00:00"
         },
         {
             "name": "pdsinterop/solid-crud",

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52be29b032feab04113911c7ac367863",
+    "content-hash": "12f2f0af65f30dd89c622c56c268f852",
     "packages": [
         {
             "name": "arc/base",
@@ -1486,16 +1486,16 @@
         },
         {
             "name": "pdsinterop/solid-auth",
-            "version": "v0.8.1",
+            "version": "v0.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdsinterop/php-solid-auth.git",
-                "reference": "176fe0fb3b19e06ab786b1cf47ee2c828c7f53c0"
+                "reference": "fc3abfa1470eed949d1418e843c5a33255c6b178"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/176fe0fb3b19e06ab786b1cf47ee2c828c7f53c0",
-                "reference": "176fe0fb3b19e06ab786b1cf47ee2c828c7f53c0",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/fc3abfa1470eed949d1418e843c5a33255c6b178",
+                "reference": "fc3abfa1470eed949d1418e843c5a33255c6b178",
                 "shasum": ""
             },
             "require": {
@@ -1529,9 +1529,9 @@
             "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
             "support": {
                 "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.8.1"
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.8.2"
             },
-            "time": "2022-09-28T12:32:07+00:00"
+            "time": "2022-09-28T12:50:40+00:00"
         },
         {
             "name": "pdsinterop/solid-crud",

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab258d6208b4a89c140fb21224963a88",
+    "content-hash": "442305e84dea7a1af38ca3c380e2221d",
     "packages": [
         {
             "name": "arc/base",
@@ -1302,16 +1302,16 @@
         },
         {
             "name": "ml/json-ld",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lanthaler/JsonLD.git",
-                "reference": "c74a1aed5979ed1cfb1be35a55a305fd30e30b93"
+                "reference": "537e68e87a6bce23e57c575cd5dcac1f67ce25d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lanthaler/JsonLD/zipball/c74a1aed5979ed1cfb1be35a55a305fd30e30b93",
-                "reference": "c74a1aed5979ed1cfb1be35a55a305fd30e30b93",
+                "url": "https://api.github.com/repos/lanthaler/JsonLD/zipball/537e68e87a6bce23e57c575cd5dcac1f67ce25d8",
+                "reference": "537e68e87a6bce23e57c575cd5dcac1f67ce25d8",
                 "shasum": ""
             },
             "require": {
@@ -1349,9 +1349,9 @@
             ],
             "support": {
                 "issues": "https://github.com/lanthaler/JsonLD/issues",
-                "source": "https://github.com/lanthaler/JsonLD/tree/1.2.0"
+                "source": "https://github.com/lanthaler/JsonLD/tree/1.2.1"
             },
-            "time": "2020-06-16T17:45:06+00:00"
+            "time": "2022-09-29T08:45:17+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1486,16 +1486,16 @@
         },
         {
             "name": "pdsinterop/solid-auth",
-            "version": "v0.9.0",
+            "version": "v0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdsinterop/php-solid-auth.git",
-                "reference": "ea830b64a62468eda6afdbc3fb15231036d32ef5"
+                "reference": "e5453e01792f9c3be8682c85b92615a0fc14eb0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/ea830b64a62468eda6afdbc3fb15231036d32ef5",
-                "reference": "ea830b64a62468eda6afdbc3fb15231036d32ef5",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/e5453e01792f9c3be8682c85b92615a0fc14eb0b",
+                "reference": "e5453e01792f9c3be8682c85b92615a0fc14eb0b",
                 "shasum": ""
             },
             "require": {
@@ -1529,9 +1529,9 @@
             "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
             "support": {
                 "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.9.0"
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.10.0"
             },
-            "time": "2022-09-30T07:51:27+00:00"
+            "time": "2022-09-30T11:29:01+00:00"
         },
         {
             "name": "pdsinterop/solid-crud",
@@ -1965,12 +1965,12 @@
             "version": "0.1.6",
             "source": {
                 "type": "git",
-                "url": "git@gitlab.com:stella-maris/clock.git",
+                "url": "https://github.com/stella-maris-solutions/clock.git",
                 "reference": "a94228dac03c9a8411198ce8c8dacbbe99c930c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=a94228dac03c9a8411198ce8c8dacbbe99c930c3",
+                "url": "https://api.github.com/repos/stella-maris-solutions/clock/zipball/a94228dac03c9a8411198ce8c8dacbbe99c930c3",
                 "reference": "a94228dac03c9a8411198ce8c8dacbbe99c930c3",
                 "shasum": ""
             },
@@ -2001,6 +2001,10 @@
                 "point in time",
                 "psr20"
             ],
+            "support": {
+                "issues": "https://github.com/stella-maris-solutions/clock/issues",
+                "source": "https://github.com/stella-maris-solutions/clock/tree/0.1.6"
+            },
             "time": "2022-09-27T15:03:11+00:00"
         },
         {

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d63fb5c291e8f16e3e0b5cd42de117c",
+    "content-hash": "135df12c9b24674679159e63387ae129",
     "packages": [
         {
             "name": "arc/base",
@@ -433,25 +433,24 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.14.0",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "6cb35f61913f06b2c91075db00f67cfd78869e28"
+                "reference": "5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/6cb35f61913f06b2c91075db00f67cfd78869e28",
-                "reference": "6cb35f61913f06b2c91075db00f67cfd78869e28",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5",
+                "reference": "5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
             "conflict": {
-                "phpspec/prophecy": "<1.9.0",
                 "zendframework/zend-diactoros": "*"
             },
             "provide": {
@@ -464,10 +463,9 @@
                 "ext-gd": "*",
                 "ext-libxml": "*",
                 "http-interop/http-factory-tests": "^0.9.0",
-                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-coding-standard": "^2.4.0",
                 "php-http/psr7-integration-tests": "^1.1.1",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.5.23",
                 "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.24.0"
             },
@@ -528,7 +526,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-07-28T12:23:48+00:00"
+            "time": "2022-08-30T17:01:46+00:00"
         },
         {
             "name": "lcobucci/clock",
@@ -1010,37 +1008,38 @@
         },
         {
             "name": "league/uri",
-            "version": "6.7.1",
+            "version": "6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "2d7c87a0860f3126a39f44a8a9bf2fed402dcfea"
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/2d7c87a0860f3126a39f44a8a9bf2fed402dcfea",
-                "reference": "2d7c87a0860f3126a39f44a8a9bf2fed402dcfea",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "league/uri-interfaces": "^2.3",
-                "php": "^7.4 || ^8.0",
-                "psr/http-message": "^1.0"
+                "php": "^8.1",
+                "psr/http-message": "^1.0.1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.3.2",
-                "nyholm/psr7": "^1.5",
-                "php-http/psr7-integration-tests": "^1.1",
-                "phpstan/phpstan": "^1.2.0",
+                "friendsofphp/php-cs-fixer": "^v3.9.5",
+                "nyholm/psr7": "^1.5.1",
+                "php-http/psr7-integration-tests": "^1.1.1",
+                "phpbench/phpbench": "^1.2.6",
+                "phpstan/phpstan": "^1.8.5",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.1.0",
-                "phpunit/phpunit": "^9.5.10",
-                "psr/http-factory": "^1.0"
+                "phpstan/phpstan-phpunit": "^1.1.1",
+                "phpstan/phpstan-strict-rules": "^1.4.3",
+                "phpunit/phpunit": "^9.5.24",
+                "psr/http-factory": "^1.0.1"
             },
             "suggest": {
                 "ext-fileinfo": "Needed to create Data URI from a filepath",
@@ -1097,7 +1096,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri/issues",
-                "source": "https://github.com/thephpleague/uri/tree/6.7.1"
+                "source": "https://github.com/thephpleague/uri/tree/6.8.0"
             },
             "funding": [
                 {
@@ -1105,7 +1104,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-29T09:48:18+00:00"
+            "time": "2022-09-13T19:58:47+00:00"
         },
         {
             "name": "league/uri-interfaces",
@@ -1488,16 +1487,16 @@
         },
         {
             "name": "pdsinterop/solid-auth",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdsinterop/php-solid-auth.git",
-                "reference": "d5ae7e9e2b8baa54047e7c3e3be4952345003e9e"
+                "reference": "e705275694ab9d9f9df9fe62b2fc4bc76e1f1281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/d5ae7e9e2b8baa54047e7c3e3be4952345003e9e",
-                "reference": "d5ae7e9e2b8baa54047e7c3e3be4952345003e9e",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/e705275694ab9d9f9df9fe62b2fc4bc76e1f1281",
+                "reference": "e705275694ab9d9f9df9fe62b2fc4bc76e1f1281",
                 "shasum": ""
             },
             "require": {
@@ -1513,7 +1512,7 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ext-xml": "*",
-                "phpunit/phpunit": "^8.5 | ^9.5"
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "autoload": {
@@ -1531,9 +1530,9 @@
             "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
             "support": {
                 "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.7.0"
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.8.0"
             },
-            "time": "2022-08-24T08:26:45+00:00"
+            "time": "2022-09-23T09:30:08+00:00"
         },
         {
             "name": "pdsinterop/solid-crud",
@@ -2263,16 +2262,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.14.0",
+            "version": "v4.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
                 "shasum": ""
             },
             "require": {
@@ -2313,9 +2312,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
             },
-            "time": "2022-05-31T20:59:12+00:00"
+            "time": "2022-09-04T07:30:47+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2430,16 +2429,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.16",
+            "version": "9.2.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073"
+                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2593003befdcc10db5e213f9f28814f5aa8ac073",
-                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
                 "shasum": ""
             },
             "require": {
@@ -2495,7 +2494,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
             },
             "funding": [
                 {
@@ -2503,7 +2502,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-20T05:26:47+00:00"
+            "time": "2022-08-30T12:24:04+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2748,16 +2747,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.23",
+            "version": "9.5.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "888556852e7e9bbeeedb9656afe46118765ade34"
+                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/888556852e7e9bbeeedb9656afe46118765ade34",
-                "reference": "888556852e7e9bbeeedb9656afe46118765ade34",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
                 "shasum": ""
             },
             "require": {
@@ -2786,7 +2785,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.0",
+                "sebastian/type": "^3.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -2830,7 +2829,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
             },
             "funding": [
                 {
@@ -2842,7 +2841,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-22T14:01:36+00:00"
+            "time": "2022-08-30T07:42:16+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3013,16 +3012,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
@@ -3075,7 +3074,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
             },
             "funding": [
                 {
@@ -3083,7 +3082,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:49:45+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3273,16 +3272,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
                 "shasum": ""
             },
             "require": {
@@ -3338,7 +3337,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3346,7 +3345,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T14:18:36+00:00"
+            "time": "2022-09-14T06:03:37+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3701,16 +3700,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
-                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
                 "shasum": ""
             },
             "require": {
@@ -3722,7 +3721,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3745,7 +3744,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
             },
             "funding": [
                 {
@@ -3753,7 +3752,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-15T09:54:48+00:00"
+            "time": "2022-09-12T14:47:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3866,7 +3865,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0",
+        "ext-dom": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "ext-openssl": "*"
     },
     "platform-dev": [],

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -1008,38 +1008,37 @@
         },
         {
             "name": "league/uri",
-            "version": "6.8.0",
+            "version": "6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39"
+                "reference": "d3b50812dd51f3fbf176344cc2981db03d10fe06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39",
-                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/d3b50812dd51f3fbf176344cc2981db03d10fe06",
+                "reference": "d3b50812dd51f3fbf176344cc2981db03d10fe06",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "league/uri-interfaces": "^2.3",
-                "php": "^8.1",
-                "psr/http-message": "^1.0.1"
+                "php": "^7.4 || ^8.0",
+                "psr/http-message": "^1.0"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.9.5",
-                "nyholm/psr7": "^1.5.1",
-                "php-http/psr7-integration-tests": "^1.1.1",
-                "phpbench/phpbench": "^1.2.6",
-                "phpstan/phpstan": "^1.8.5",
+                "friendsofphp/php-cs-fixer": "^v3.3.2",
+                "nyholm/psr7": "^1.5",
+                "php-http/psr7-integration-tests": "^1.1",
+                "phpstan/phpstan": "^1.2.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.1.1",
-                "phpstan/phpstan-strict-rules": "^1.4.3",
-                "phpunit/phpunit": "^9.5.24",
-                "psr/http-factory": "^1.0.1"
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.10",
+                "psr/http-factory": "^1.0"
             },
             "suggest": {
                 "ext-fileinfo": "Needed to create Data URI from a filepath",
@@ -1096,7 +1095,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri/issues",
-                "source": "https://github.com/thephpleague/uri/tree/6.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/6.7.2"
             },
             "funding": [
                 {
@@ -1104,7 +1103,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-13T19:58:47+00:00"
+            "time": "2022-09-13T19:50:42+00:00"
         },
         {
             "name": "league/uri-interfaces",
@@ -4235,5 +4234,5 @@
         "ext-openssl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -1008,38 +1008,37 @@
         },
         {
             "name": "league/uri",
-            "version": "6.8.0",
+            "version": "6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39"
+                "reference": "d3b50812dd51f3fbf176344cc2981db03d10fe06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39",
-                "reference": "a700b4656e4c54371b799ac61e300ab25a2d1d39",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/d3b50812dd51f3fbf176344cc2981db03d10fe06",
+                "reference": "d3b50812dd51f3fbf176344cc2981db03d10fe06",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "league/uri-interfaces": "^2.3",
-                "php": "^8.1",
-                "psr/http-message": "^1.0.1"
+                "php": "^7.4 || ^8.0",
+                "psr/http-message": "^1.0"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.9.5",
-                "nyholm/psr7": "^1.5.1",
-                "php-http/psr7-integration-tests": "^1.1.1",
-                "phpbench/phpbench": "^1.2.6",
-                "phpstan/phpstan": "^1.8.5",
+                "friendsofphp/php-cs-fixer": "^v3.3.2",
+                "nyholm/psr7": "^1.5",
+                "php-http/psr7-integration-tests": "^1.1",
+                "phpstan/phpstan": "^1.2.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.1.1",
-                "phpstan/phpstan-strict-rules": "^1.4.3",
-                "phpunit/phpunit": "^9.5.24",
-                "psr/http-factory": "^1.0.1"
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.10",
+                "psr/http-factory": "^1.0"
             },
             "suggest": {
                 "ext-fileinfo": "Needed to create Data URI from a filepath",
@@ -1096,7 +1095,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri/issues",
-                "source": "https://github.com/thephpleague/uri/tree/6.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/6.7.2"
             },
             "funding": [
                 {
@@ -1104,7 +1103,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-13T19:58:47+00:00"
+            "time": "2022-09-13T19:50:42+00:00"
         },
         {
             "name": "league/uri-interfaces",

--- a/solid/composer.lock
+++ b/solid/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12a2c4145b59310bde3d280fa2b453f9",
+    "content-hash": "52be29b032feab04113911c7ac367863",
     "packages": [
         {
             "name": "arc/base",
@@ -1486,16 +1486,16 @@
         },
         {
             "name": "pdsinterop/solid-auth",
-            "version": "v0.8.0",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdsinterop/php-solid-auth.git",
-                "reference": "e705275694ab9d9f9df9fe62b2fc4bc76e1f1281"
+                "reference": "176fe0fb3b19e06ab786b1cf47ee2c828c7f53c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/e705275694ab9d9f9df9fe62b2fc4bc76e1f1281",
-                "reference": "e705275694ab9d9f9df9fe62b2fc4bc76e1f1281",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/176fe0fb3b19e06ab786b1cf47ee2c828c7f53c0",
+                "reference": "176fe0fb3b19e06ab786b1cf47ee2c828c7f53c0",
                 "shasum": ""
             },
             "require": {
@@ -1529,9 +1529,9 @@
             "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
             "support": {
                 "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.8.0"
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.8.1"
             },
-            "time": "2022-09-23T09:30:08+00:00"
+            "time": "2022-09-28T12:32:07+00:00"
         },
         {
             "name": "pdsinterop/solid-crud",

--- a/solid/lib/Controller/CalendarController.php
+++ b/solid/lib/Controller/CalendarController.php
@@ -1,23 +1,20 @@
 <?php
 namespace OCA\Solid\Controller;
 
-use OCA\Solid\ServerConfig;
 use OCA\Solid\PlainResponse;
 
-use OCP\IRequest;
-use OCP\IUserManager;
-use OCP\IURLGenerator;
-use OCP\ISession;
-use OCP\IConfig;
-
-use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Response;
-use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+
+use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
-use Pdsinterop\Solid\Auth\Utils\DPop as DPop;
-use Pdsinterop\Solid\Auth\WAC as WAC;
 
 class CalendarController extends Controller {
 	/* @var IURLGenerator */

--- a/solid/lib/Controller/CalendarController.php
+++ b/solid/lib/Controller/CalendarController.php
@@ -1,6 +1,7 @@
 <?php
 namespace OCA\Solid\Controller;
 
+use OCA\Solid\DpopFactoryTrait;
 use OCA\Solid\PlainResponse;
 
 use OCP\AppFramework\Controller;
@@ -17,20 +18,33 @@ use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
 
 class CalendarController extends Controller {
+	use DpopFactoryTrait;
+
 	/* @var IURLGenerator */
 	private $urlGenerator;
 
 	/* @var ISession */
 	private $session;
 	
-	public function __construct($AppName, IRequest $request, ISession $session, IUserManager $userManager, IURLGenerator $urlGenerator, $userId, IConfig $config, \OCA\Solid\Service\UserService $UserService) 
-	{
+	public function __construct(
+		$AppName,
+		IRequest $request,
+		ISession $session,
+		IUserManager $userManager,
+		IURLGenerator $urlGenerator,
+		$userId,
+		IConfig $config,
+		\OCA\Solid\Service\UserService $UserService,
+		IDBConnection $connection,
+	) {
 		parent::__construct($AppName, $request);
 		require_once(__DIR__.'/../../vendor/autoload.php');
 		$this->config = new \OCA\Solid\ServerConfig($config, $urlGenerator, $userManager);
 		$this->request     = $request;
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
+
+		$this->setJtiStorage($connection);
 	}
 
 	private function getFileSystem($userId) {
@@ -116,7 +130,6 @@ EOF;
 
 		$this->resourceServer = new ResourceServer($this->filesystem, $this->response);		
         $this->WAC = new WAC($this->filesystem);
-		$this->DPop = new DPop();
 
 		$request = $this->rawRequest;
 		$baseUrl = $this->getCalendarUrl($userId);		
@@ -125,10 +138,13 @@ EOF;
 		$pubsub = getenv('PUBSUB_URL') ?: ("http://pubsub:8080/");
 		$this->resourceServer->setPubSubUrl($pubsub);
 
+		$dpop = $this->getDpop();
+
 		try {
-			$webId = $this->DPop->getWebId($request);
-		} catch(\Exception $e) {
-			$response = $this->resourceServer->getResponse()->withStatus(409, "Invalid token");
+			$webId = $dpop->getWebId($request);
+		} catch(\Pdsinterop\Solid\Auth\Exception\Exception $e) {
+			$response = $this->resourceServer->getResponse()
+				->withStatus(Http::STATUS_CONFLICT, "Invalid token " . $e->getMessage());
 			return $this->respond($response);
 		}
 		

--- a/solid/lib/Controller/ContactsController.php
+++ b/solid/lib/Controller/ContactsController.php
@@ -1,23 +1,20 @@
 <?php
 namespace OCA\Solid\Controller;
 
-use OCA\Solid\ServerConfig;
 use OCA\Solid\PlainResponse;
 
-use OCP\IRequest;
-use OCP\IUserManager;
-use OCP\IURLGenerator;
-use OCP\ISession;
-use OCP\IConfig;
-
-use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Response;
-use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+
+use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
-use Pdsinterop\Solid\Auth\Utils\DPop as DPop;
-use Pdsinterop\Solid\Auth\WAC as WAC;
 
 class ContactsController extends Controller {
 	/* @var IURLGenerator */

--- a/solid/lib/Controller/ContactsController.php
+++ b/solid/lib/Controller/ContactsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace OCA\Solid\Controller;
 
+use OCA\Solid\DpopFactoryTrait;
 use OCA\Solid\PlainResponse;
 
 use OCP\AppFramework\Controller;
@@ -17,20 +18,34 @@ use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
 
 class ContactsController extends Controller {
+
+	use DpopFactoryTrait;
+
 	/* @var IURLGenerator */
 	private $urlGenerator;
 
 	/* @var ISession */
 	private $session;
 	
-	public function __construct($AppName, IRequest $request, ISession $session, IUserManager $userManager, IURLGenerator $urlGenerator, $userId, IConfig $config, \OCA\Solid\Service\UserService $UserService) 
-	{
+	public function __construct(
+		$AppName,
+		IRequest $request,
+		ISession $session,
+		IUserManager $userManager,
+		IURLGenerator $urlGenerator,
+		$userId,
+		IConfig $config,
+		\OCA\Solid\Service\UserService $UserService,
+		IDBConnection $connection,
+	) {
 		parent::__construct($AppName, $request);
 		require_once(__DIR__.'/../../vendor/autoload.php');
 		$this->config = new \OCA\Solid\ServerConfig($config, $urlGenerator, $userManager);
 		$this->request     = $request;
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
+
+		$this->setJtiStorage($connection);
 	}
 
 	private function getFileSystem($userId) {
@@ -115,8 +130,7 @@ EOF;
 		$this->filesystem = $this->getFileSystem($userId);
 
 		$this->resourceServer = new ResourceServer($this->filesystem, $this->response);		
-        $this->WAC = new WAC($this->filesystem);
-		$this->DPop = new DPop();
+       $this->WAC = new WAC($this->filesystem);
 
 		$request = $this->rawRequest;
 		$baseUrl = $this->getContactsUrl($userId);		
@@ -125,10 +139,13 @@ EOF;
 		$pubsub = getenv('PUBSUB_URL') ?: ("http://pubsub:8080/");
 		$this->resourceServer->setPubSubUrl($pubsub);
 
+		$dpop = $this->getDpop();
+
 		try {
-			$webId = $this->DPop->getWebId($request);
-		} catch(\Exception $e) {
-			$response = $this->resourceServer->getResponse()->withStatus(409, "Invalid token");
+			$webId = $dpop->getWebId($request);
+		} catch(\Pdsinterop\Solid\Auth\Exception\Exception $e) {
+			$response = $this->resourceServer->getResponse()
+				->withStatus(Http::STATUS_CONFLICT, "Invalid token " . $e->getMessage());
 			return $this->respond($response);
 		}
 		

--- a/solid/lib/Controller/ContactsController.php
+++ b/solid/lib/Controller/ContactsController.php
@@ -17,8 +17,8 @@ use OCP\IUserManager;
 use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
 
-class ContactsController extends Controller {
-
+class ContactsController extends Controller
+{
 	use DpopFactoryTrait;
 
 	/* @var IURLGenerator */

--- a/solid/lib/Controller/ProfileController.php
+++ b/solid/lib/Controller/ProfileController.php
@@ -1,25 +1,21 @@
 <?php
 namespace OCA\Solid\Controller;
 
-use OCA\Solid\ServerConfig;
 use OCA\Solid\PlainResponse;
 
-use OCP\IRequest;
-use OCP\IUserManager;
-use OCP\Contacts\IManager;
-use OCP\IURLGenerator;
-use OCP\ISession;
-use OCP\IConfig;
-
-use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Response;
-use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Controller;
-use Pdsinterop\Solid\Resources\Server as ResourceServer;
-use Pdsinterop\Solid\Auth\Utils\DPop as DPop;
-use Pdsinterop\Solid\Auth\WAC as WAC;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Contacts\IManager;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
 
+use Pdsinterop\Solid\Auth\WAC;
+use Pdsinterop\Solid\Resources\Server as ResourceServer;
 
 class ProfileController extends Controller {
 	/* @var IURLGenerator */

--- a/solid/lib/Controller/ServerController.php
+++ b/solid/lib/Controller/ServerController.php
@@ -2,19 +2,17 @@
 namespace OCA\Solid\Controller;
 
 use OCA\Solid\ServerConfig;
-use OCP\IRequest;
-use OCP\IUserManager;
-use OCP\IURLGenerator;
-use OCP\ISession;
-use OCP\IConfig;
 
-use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\TemplateResponse;
-use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\DataResponse;
-use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Controller;
-use Pdsinterop\Solid\Auth\Utils\DPop as DPop;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
 
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;

--- a/solid/lib/Controller/ServerController.php
+++ b/solid/lib/Controller/ServerController.php
@@ -19,8 +19,8 @@ use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 
-class ServerController extends Controller {
-
+class ServerController extends Controller
+{
 	use DpopFactoryTrait;
 
 	private $userId;

--- a/solid/lib/Controller/ServerController.php
+++ b/solid/lib/Controller/ServerController.php
@@ -40,11 +40,11 @@ class ServerController extends Controller {
 
 	/* @var Pdsinterop\Solid\Auth\Factory\AuthorizationServerFactory */
 	private $authServerFactory;
-	
+
 	/* @var Pdsinterop\Solid\Auth\TokenGenerator */
 	private $tokenGenerator;
-	
-	public function __construct($AppName, IRequest $request, ISession $session, IUserManager $userManager, IURLGenerator $urlGenerator, $userId, IConfig $config, \OCA\Solid\Service\UserService $UserService) 
+
+	public function __construct($AppName, IRequest $request, ISession $session, IUserManager $userManager, IURLGenerator $urlGenerator, $userId, IConfig $config, \OCA\Solid\Service\UserService $UserService)
 	{
 		parent::__construct($AppName, $request);
 		require_once(__DIR__.'/../../vendor/autoload.php');
@@ -55,8 +55,8 @@ class ServerController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
 
-		$this->authServerConfig = $this->createAuthServerConfig(); 
-		$this->authServerFactory = (new \Pdsinterop\Solid\Auth\Factory\AuthorizationServerFactory($this->authServerConfig))->create();		
+		$this->authServerConfig = $this->createAuthServerConfig();
+		$this->authServerFactory = (new \Pdsinterop\Solid\Auth\Factory\AuthorizationServerFactory($this->authServerConfig))->create();
 		$this->tokenGenerator = (new \Pdsinterop\Solid\Auth\TokenGenerator($this->authServerConfig));
 	}
 
@@ -72,10 +72,10 @@ class ServerController extends Controller {
 			"registration_endpoint" => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.server.register"))
 		];
 	}
-	
+
 	private function getKeys() {
 		$encryptionKey = $this->config->getEncryptionKey();
-		$privateKey    = $this->config->getPrivateKey();		
+		$privateKey    = $this->config->getPrivateKey();
 		$key           = openssl_pkey_get_private($privateKey);
 		$publicKey     = openssl_pkey_get_details($key)['key'];
 		return [
@@ -84,7 +84,7 @@ class ServerController extends Controller {
 			"publicKey"     => $publicKey
 		];
 	}
-	
+
 	private function createAuthServerConfig() {
 		$clientId = isset($_GET['client_id']) ? $_GET['client_id'] : null;
 		$client = $this->getClient($clientId);
@@ -164,7 +164,7 @@ class ServerController extends Controller {
 			}
 		}
 		$clientId = $getVars['client_id'];
-		$approval = $this->checkApproval($clientId);	
+		$approval = $this->checkApproval($clientId);
 		if (!$approval) {
 			$result = new JSONResponse('Approval required');
 			$result->setStatus(302);
@@ -182,7 +182,7 @@ class ServerController extends Controller {
 
 		$response = $server->respondToAuthorizationRequest($request, $user, $approval);
 		$response = $this->tokenGenerator->addIdTokenToResponse($response, $clientId, $this->getProfilePage(), $this->session->get("nonce"), $this->config->getPrivateKey());
-		
+
 		return $this->respond($response); // ->addHeader('Access-Control-Allow-Origin', '*');
 	}
 
@@ -200,7 +200,7 @@ class ServerController extends Controller {
 			return \Pdsinterop\Solid\Auth\Enum\Authorization::DENIED;
 		}
 	}
-	
+
 	private function getProfilePage() {
 		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.profile.handleGet", array("userId" => $this->userId, "path" => "/card"))) . "#me";
 	}
@@ -228,7 +228,7 @@ class ServerController extends Controller {
 	public function session() {
 		return new JSONResponse("ok");
 	}
-	
+
 	/**
 	 * @PublicPage
 	 * @NoAdminRequired
@@ -309,7 +309,7 @@ class ServerController extends Controller {
 //		->addHeader('Access-Control-Allow-Origin', $origin)
 //		->addHeader('Access-Control-Allow-Methods', 'POST');
 	}
-	
+
 	/**
 	 * @PublicPage
 	 * @NoAdminRequired
@@ -320,7 +320,6 @@ class ServerController extends Controller {
 		unset($clientRegistration['client_secret']);
 		return new JSONResponse($clientRegistration);
 	}
-	
 
 	/**
 	 * @PublicPage
@@ -351,7 +350,7 @@ class ServerController extends Controller {
 			$body = 'ok';
 		}
 		$result = new JSONResponse($body);
-		
+
 		foreach ($headers as $header => $values) {
 			foreach ($values as $value) {
 				$result->addHeader($header, $value);

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -210,6 +210,7 @@ EOF;
 		$preferences = <<< EOF
 # Preferences
 @prefix : <#>.
+@prefix sp: <http://www.w3.org/ns/pim/space#>.
 @prefix dct: <http://purl.org/dc/terms/>.
 @prefix profile: <{user-profile-uri}>.
 @prefix solid: <http://www.w3.org/ns/solid/terms#>.

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -17,8 +17,8 @@ use OCP\IUserManager;
 use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
 
-class StorageController extends Controller {
-
+class StorageController extends Controller
+{
 	use DpopFactoryTrait;
 
 	/* @var IURLGenerator */

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -1,26 +1,20 @@
 <?php
 namespace OCA\Solid\Controller;
 
-use OCA\Solid\ServerConfig;
 use OCA\Solid\PlainResponse;
 
-use OCP\IRequest;
-use OCP\IUserManager;
-use OCP\IURLGenerator;
-use OCP\ISession;
-use OCP\IConfig;
-
-use OCP\Files\IRootFolder;
-use OCP\Files\IHomeStorage;
-use OCP\Files\SimpleFS\ISimpleRoot;
-use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Response;
-use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\Files\IRootFolder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+
+use Pdsinterop\Solid\Auth\WAC;
 use Pdsinterop\Solid\Resources\Server as ResourceServer;
-use Pdsinterop\Solid\Auth\Utils\DPop as DPop;
-use Pdsinterop\Solid\Auth\WAC as WAC;
 
 class StorageController extends Controller {
 	/* @var IURLGenerator */

--- a/solid/lib/Controller/StorageController.php
+++ b/solid/lib/Controller/StorageController.php
@@ -222,7 +222,7 @@ EOF;
 profile:me
 	a solid:Developer;
 	solid:privateTypeIndex <privateTypeIndex.ttl>;
-	solid:publicTypeIndex <publicTypeIndex.ttl>;
+	solid:publicTypeIndex <publicTypeIndex.ttl>.
 EOF;
 
 		$profileUri = $this->getUserProfile($userId);

--- a/solid/lib/DpopFactoryTrait.php
+++ b/solid/lib/DpopFactoryTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace OCA\Solid;
+
+use DateInterval;
+use OCP\IDBConnection;
+use Pdsinterop\Solid\Auth\Utils\DPop;
+use Pdsinterop\Solid\Auth\Utils\JtiValidator;
+
+trait DpopFactoryTrait
+{
+    ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    private IDBConnection $connection;
+    private DateInterval $validFor;
+
+    //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    final public function getDpop(): DPop
+    {
+        $interval = $this->getDpopValidFor();
+
+        $replayDetector = new JtiReplayDetector($interval, $this->connection);
+
+        $jtiValidator = new JtiValidator($replayDetector);
+
+        return new DPop($jtiValidator);
+    }
+
+    final public function getDpopValidFor(): DateInterval
+    {
+        static $validFor;
+
+        if ($validFor === null) {
+            $validFor = new DateInterval('PT10M');
+        }
+
+        return $validFor;
+    }
+
+    final public function setJtiStorage(IDBConnection $connection): void
+    {
+        $this->connection = $connection;
+    }
+
+    ////////////////////////////// UTILITY METHODS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+}

--- a/solid/lib/JtiReplayDetector.php
+++ b/solid/lib/JtiReplayDetector.php
@@ -23,16 +23,13 @@ class JtiReplayDetector implements ReplayDetectorInterface
     public function detect(string $jti, string $targetUri): bool
     {
         // @TODO: $this->rotateBuckets();
-
         $has = $this->has($jti, $targetUri);
-
-        $detected = $has === false;
 
         if ($has === false) {
             $this->store($jti, $targetUri);
         }
 
-        return $detected;
+        return $has;
     }
 
     ////////////////////////////// UTILITY METHODS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\

--- a/solid/lib/JtiReplayDetector.php
+++ b/solid/lib/JtiReplayDetector.php
@@ -10,14 +10,15 @@ use Pdsinterop\Solid\Auth\ReplayDetectorInterface;
 
 class JtiReplayDetector implements ReplayDetectorInterface
 {
-
     ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
     private string $table = 'solid_jti';
 
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-    public function __construct(private DateInterval $interval, private IDBConnection $connection) {}
+    public function __construct(private DateInterval $interval, private IDBConnection $connection)
+    {
+    }
 
     public function detect(string $jti, string $targetUri): bool
     {

--- a/solid/lib/JtiReplayDetector.php
+++ b/solid/lib/JtiReplayDetector.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OCA\Solid;
+
+use DateInterval;
+use DateTime;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Pdsinterop\Solid\Auth\ReplayDetectorInterface;
+
+class JtiReplayDetector implements ReplayDetectorInterface
+{
+
+    ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    private string $table = 'solid_jti';
+
+    //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    public function __construct(private DateInterval $interval, private IDBConnection $connection) {}
+
+    public function detect(string $jti, string $targetUri): bool
+    {
+        // @TODO: $this->rotateBuckets();
+
+        $has = $this->has($jti, $targetUri);
+
+        $detected = $has === false;
+
+        if ($has === false) {
+            $this->store($jti, $targetUri);
+        }
+
+        return $detected;
+    }
+
+    ////////////////////////////// UTILITY METHODS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    private function has(string $jti, string $uri): bool
+    {
+        $queryBuilder = $this->connection->getQueryBuilder();
+
+        $notOlderThan = (new DateTime())->sub($this->interval);
+
+        $cursor = $queryBuilder->select('*')
+            ->from($this->table)
+            ->where(
+                $queryBuilder->expr()->eq('jti', $queryBuilder->createNamedParameter($jti,IQueryBuilder::PARAM_STR))
+            )
+            ->andWhere(
+                $queryBuilder->expr()->eq('uri', $queryBuilder->createNamedParameter($uri, IQueryBuilder::PARAM_STR))
+            )
+            ->andWhere(
+                $queryBuilder->expr()->gt('request_time', $queryBuilder->createParameter('notOlderThan'))
+            )->setParameter('notOlderThan', $notOlderThan, 'datetime')
+            ->execute()
+        ;
+
+        $row = $cursor->fetch();
+
+        $cursor->closeCursor();
+
+        return ! empty($row);
+    }
+
+    private function store(string $jti, string $uri): void
+    {
+        $queryBuilder = $this->connection->getQueryBuilder();
+
+        $queryBuilder->insert($this->table)
+            ->values([
+                'jti' => $queryBuilder->createNamedParameter($jti),
+                'uri' => $queryBuilder->createNamedParameter($uri),
+            ])
+            ->executeStatement()
+        ;
+    }
+}

--- a/solid/lib/Migration/Version000000Date20220923134100.php
+++ b/solid/lib/Migration/Version000000Date20220923134100.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Solid\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version000000Date20220923134100 extends SimpleMigrationStep {
+    /**
+     * @param IOutput $output
+     * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+     * @param array $options
+     *
+     * @return null|ISchemaWrapper
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('solid_jti') === false) {
+            $table = $schema->createTable('solid_jti');
+
+            $table->addColumn('id', Types::INTEGER, [
+                'autoincrement' => true,
+                'notnull' => true,
+            ]);
+
+            $table->addColumn('jti', Types::STRING, [
+                'length' => 255,
+                'notnull' => true,
+            ]);
+
+            $table->addColumn('uri', Types::STRING, [
+                'length' => 2048,
+                'notnull' => true,
+            ]);
+
+            $table->addColumn('request_time', Types::DATETIME, [
+                'default' => 'CURRENT_TIMESTAMP',
+                'notnull' => true,
+            ]);
+
+            $table->setPrimaryKey(['id']);
+            $table->addIndex(['jti', 'uri']);
+        }
+
+        return $schema;
+    }
+}

--- a/solid/tests/Unit/JtiReplayDetectorTest.php
+++ b/solid/tests/Unit/JtiReplayDetectorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace OCA\Solid;
+
+use DateInterval;
+use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\IResult;
+use PHPUnit\Framework\TestCase;
+require_once __DIR__.'/../../lib/JtiReplayDetector.php';
+
+class JtiReplayDetectorTest extends TestCase {
+
+	private function createMocks($result) {
+		$mockIDBConnection = $this->createMock(IDBConnection::class);
+		$mockQueryBuilder = $this->createMock(IQueryBuilder::class);
+		$mockExpr = $this->createMock(IExpressionBuilder::class);
+		$mockResult = $this->createMock(IResult::class);
+		
+		$mockIDBConnection->expects($this->any())
+			->method('getQueryBuilder')
+			->willReturn($mockQueryBuilder);
+		$mockQueryBuilder->expects($this->once())
+			->method('select')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->any())
+			->method('expr')
+			->willReturn($mockExpr);
+		$mockExpr->expects($this->any())
+			->method('eq')
+			->willReturn("");
+		$mockQueryBuilder->expects($this->once())
+			->method('from')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->once())
+			->method('where')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->any())
+			->method('andWhere')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->once())
+			->method('setParameter')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->once())
+			->method('execute')
+			->willReturn($mockResult);
+		$mockResult->expects($this->once())
+			->method('fetch')
+			->willReturn($result);
+		$mockResult->expects($this->once())
+			->method('closeCursor');
+		$mockQueryBuilder->expects($this->any())
+			->method('insert')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->any())
+			->method('values')
+			->willReturnSelf();
+		$mockQueryBuilder->expects($this->any())
+			->method('executeStatement');
+
+		return $mockIDBConnection;
+	}
+
+	public function testJtiDetected() {
+		$dateInterval = new DateInterval('PT90S');
+		$mockIDBConnection = $this->createMocks(true);
+					
+		$detector = new JtiReplayDetector($dateInterval, $mockIDBConnection);
+		
+		$mockUUID = 'mockUUID-with-some-more-text';
+		$mockURI = 'mockURI';
+		$result = $detector->detect($mockUUID, $mockURI);
+
+		$this->assertTrue($result);
+	}
+
+	public function testJtiNotDetected() {
+		$dateInterval = new DateInterval('PT90S');
+		$mockIDBConnection = $this->createMocks(false);
+					
+		$detector = new JtiReplayDetector($dateInterval, $mockIDBConnection);
+		
+		$mockUUID = 'mockUUID-with-some-more-text';
+		$mockURI = 'mockURI';
+		$result = $detector->detect($mockUUID, $mockURI);
+
+		$this->assertFalse($result);
+	}
+
+}

--- a/solid/tests/Unit/JtiReplayDetectorTest.php
+++ b/solid/tests/Unit/JtiReplayDetectorTest.php
@@ -8,11 +8,16 @@ use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\IResult;
 use PHPUnit\Framework\TestCase;
-require_once __DIR__.'/../../lib/JtiReplayDetector.php';
 
-class JtiReplayDetectorTest extends TestCase {
+class JtiReplayDetectorTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__.'/../../lib/JtiReplayDetector.php';
+	}
 
-	private function createMocks($result) {
+	private function createMocks($result)
+	{
 		$mockIDBConnection = $this->createMock(IDBConnection::class);
 		$mockQueryBuilder = $this->createMock(IQueryBuilder::class);
 		$mockExpr = $this->createMock(IExpressionBuilder::class);
@@ -62,7 +67,8 @@ class JtiReplayDetectorTest extends TestCase {
 		return $mockIDBConnection;
 	}
 
-	public function testJtiDetected() {
+	public function testJtiDetected(): void
+    {
 		$dateInterval = new DateInterval('PT90S');
 		$mockIDBConnection = $this->createMocks(true);
 					
@@ -75,7 +81,8 @@ class JtiReplayDetectorTest extends TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testJtiNotDetected() {
+	public function testJtiNotDetected(): void
+	{
 		$dateInterval = new DateInterval('PT90S');
 		$mockIDBConnection = $this->createMocks(false);
 					


### PR DESCRIPTION
This MR updates the php-solid-auth lib to the latest version (which includes JTI validation) and adds an implementation for JTI storage.

this is done by adding a database table (to store JTIs) and a factory trait (to prevent code duplication).

This branch needs to be tested before this MR can move out of draft.

Closes #84 