### PR TITLE
added oidcIssuer to webid profile

### DIFF
--- a/solid/lib/Controller/ProfileController.php
+++ b/solid/lib/Controller/ProfileController.php
@@ -277,7 +277,8 @@ EOF;
 					'preferences' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/preferences.ttl"))),
 					'privateTypeIndex' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/privateTypeIndex.ttl"))),
 					'publicTypeIndex' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute("solid.storage.handleGet", array("userId" => $userId, "path" => "/settings/publicTypeIndex.ttl"))),
-					'storage' => $this->getStorageUrl($userId)
+					'storage' => $this->getStorageUrl($userId),
+					'issuer' => $this->urlGenerator->getBaseURL()
 				);
 				return $profile;
 			}
@@ -312,6 +313,7 @@ EOF;
 		solid:account ser:;
 		solid:privateTypeIndex <<?php echo $profile['privateTypeIndex']; ?>>;
 		solid:publicTypeIndex <<?php echo $profile['publicTypeIndex']; ?>>;
+		solid:oidcIssuer <<?php echo $profile['issuer']; ?>>;
 	<?php
 	foreach ($profile['friends'] as $key => $friend) {
 	?>


### PR DESCRIPTION
the webid profile did not have the required oidcIssuer predicate, so I've added that here
I've copied code to get the base url, maybe that should be a single config value in the solid-nextcloud code somewhere?