### PR TITLE
Change GitHub test suite action (and cleanup `Dockerfile` and `run-solid-test-suite.sh`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
   build-docker-nextcloud:
     runs-on: ubuntu-latest
     steps:
+      - name: Creat docker tag from git reference
+        # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
+        run: |
+          echo "TAG=$(echo -n "${{ github.ref_name }}" | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" >> "${GITHUB_ENV}"
+
       - uses: actions/cache@v3
         id: cache-solid-nextcloud-docker
         with:
@@ -41,12 +46,12 @@ jobs:
       - name: Build Solid-Nextcloud Docker image
         run: |
           docker build \
-            --tag "solid-nextcloud:${{ github.ref_name }}" \
-            --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ github.ref_name }}" \
+            --tag "solid-nextcloud:${{ env.TAG }}" \
+            --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ env.TAG }}" \
           .
-          docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ github.ref_name }}"
+          docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ env.TAG }}"
           mkdir -p cache/solid-nextcloud
-          docker image save solid-nextcloud:${{ github.ref_name }} --output ./cache/solid-nextcloud/${{ github.sha }}.tar
+          docker image save solid-nextcloud:${{ env.TAG }} --output ./cache/solid-nextcloud/${{ github.sha }}.tar
 
   solid-testsuite:
     strategy:
@@ -63,6 +68,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Creat docker tag from git reference
+        # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
+        run: |
+          echo "TAG=$(echo -n "${{ github.ref_name }}" | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" >> "${GITHUB_ENV}"
+
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
@@ -95,8 +105,8 @@ jobs:
             "ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}"
 
           source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "solid-nextcloud:${{ github.ref_name }}" ${{ matrix.test }}
-          startSolidNextcloud 'thirdparty' "solid-nextcloud:${{ github.ref_name }}" ${{ matrix.test }}
+          startSolidNextcloud 'server' "solid-nextcloud:${{ env.TAG }}" ${{ matrix.test }}
+          startSolidNextcloud 'thirdparty' "solid-nextcloud:${{ env.TAG }}" ${{ matrix.test }}
 
           echo "COOKIE_server=${COOKIE_server}" >> "${GITHUB_ENV}"
           echo "COOKIE_thirdparty=${COOKIE_thirdparty}" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source
-# code and run tests across different versions of node
-# For more information see:
-# https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
+---
 name: Solid Test Suites
 
 on:
@@ -14,90 +10,93 @@ on:
     branches: [ main ]
 
 jobs:
-  docker-build-pub-sub:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build Pub-Sub Docker image
-        run: |
-          docker build -t pubsub-server  https://github.com/pdsinterop/php-solid-pubsub-server.git#main
-          docker push ghcr.io/pdsinterop/solid-nextcloud:latest
-
   docker-build-nextcloud:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # @FIXME: In stead of `latest` docker images need to be tagged with the MR/PR reference (or commit hash)
       - name: Build Solid-Nextcloud Docker image
         run: |
-          docker build -t solid-nextcloud .
-          docker push ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+          docker build -t "ghcr.io/pdsinterop/solid-nextcloud:latest" .
+          docker push "ghcr.io/pdsinterop/solid-nextcloud:latest"
 
   run-tests:
     needs:
       - docker-build-nextcloud
-      - docker-build-pub-sub
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Solid webid-provider test suite
         run: |
           docker pull michielbdejong/nextcloud-cookie
           docker pull solidtestsuite/webid-provider-tests:v2.1.0
+          docker pull ghcr.io/pdsinterop/solid-nextcloud:latest
+          docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:latest
 
           docker network create testnet
-          docker run --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+          docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
 
           source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' 'ghcr.io/pdsinterop/solid-nextcloud'
-          startSolidNextcloud 'thirdparty' 'ghcr.io/pdsinterop/solid-nextcloud'
+          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
 
-          docker run --rm --network=testnet \
+          docker run -i --rm --network=testnet \
             --env COOKIE="$COOKIE_server" \
             --env COOKIE_ALICE="$COOKIE_server" \
             --env COOKIE_BOB="$COOKIE_thirdparty" \
             --env-file ./env-vars-testers.list \
             solidtestsuite/webid-provider-tests:v2.1.0
 
-      - name: Run Solid solid-crud test suite
-        run: |
-          docker pull michielbdejong/nextcloud-cookie
-          docker pull solidtestsuite/solid-crud-tests:v6.0.0
-
-          docker network create testnet
-          docker run --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
-
-          source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' 'ghcr.io/pdsinterop/solid-nextcloud'
-          startSolidNextcloud 'thirdparty' 'ghcr.io/pdsinterop/solid-nextcloud'
-
-          docker run --rm --network=testnet \
-            --env COOKIE="$COOKIE_server" \
-            --env COOKIE_ALICE="$COOKIE_server" \
-            --env COOKIE_BOB="$COOKIE_thirdparty" \
-            --env-file ./env-vars-testers.list \
-            solidtestsuite/solid-crud-tests:v6.0.0
-
-      - name: Run Solid web-access-control test suite
-        run: |
-          docker pull michielbdejong/nextcloud-cookie
-          docker pull solidtestsuite/web-access-control-tests:v7.1.0
-
-          docker network create testnet
-          docker run --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
-
-          source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' 'ghcr.io/pdsinterop/solid-nextcloud'
-          startSolidNextcloud 'thirdparty' 'ghcr.io/pdsinterop/solid-nextcloud'
-
-          docker run --rm --network=testnet \
-            --env COOKIE="$COOKIE_server" \
-            --env COOKIE_ALICE="$COOKIE_server" \
-            --env COOKIE_BOB="$COOKIE_thirdparty" \
-            --env-file ./env-vars-testers.list \
-            solidtestsuite/web-access-control-tests:v7.1.0
+#      - name: Run Solid solid-crud test suite
+#        run: |
+#          docker pull michielbdejong/nextcloud-cookie
+#          docker pull solidtestsuite/solid-crud-tests:v6.0.0
+#
+#          docker network create testnet
+#          docker run -i --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+#
+#          source ./run-solid-test-suite.sh
+#          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+#          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+#
+#          docker run -i --rm --network=testnet \
+#            --env COOKIE="$COOKIE_server" \
+#            --env COOKIE_ALICE="$COOKIE_server" \
+#            --env COOKIE_BOB="$COOKIE_thirdparty" \
+#            --env-file ./env-vars-testers.list \
+#            solidtestsuite/solid-crud-tests:v6.0.0
+#
+#      - name: Run Solid web-access-control test suite
+#        run: |
+#          docker pull michielbdejong/nextcloud-cookie
+#          docker pull solidtestsuite/web-access-control-tests:v7.1.0
+#
+#          docker network create testnet
+#          docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
+#
+#          source ./run-solid-test-suite.sh
+#          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+#          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+#
+#          docker run -i --rm --network=testnet \
+#            --env COOKIE="$COOKIE_server" \
+#            --env COOKIE_ALICE="$COOKIE_server" \
+#            --env COOKIE_BOB="$COOKIE_thirdparty" \
+#            --env-file ./env-vars-testers.list \
+#            solidtestsuite/web-access-control-tests:v7.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
   build-docker-nextcloud:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@v3
+        id: cache-solid-nextcloud-docker
+        with:
+          path: cache/solid-nextcloud
+          key: solid-nextcloud-docker-${{ github.sha }}
+
       - uses: actions/checkout@v3
 
       - uses: docker/login-action@v2
@@ -34,8 +40,13 @@ jobs:
 
       - name: Build Solid-Nextcloud Docker image
         run: |
-          docker build -t "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" .
+          docker build \
+            --tag "solid-nextcloud:${{ github.sha }}" \
+            --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" \
+          .
           docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}"
+          mkdir -p cache/solid-nextcloud
+          docker image save solid-nextcloud:${{ github.sha }} --output ./cache/solid-nextcloud/${{ github.sha }}.tar
 
   solid-testsuite:
     strategy:
@@ -54,6 +65,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/cache@v3
+        id: cache-solid-nextcloud-docker
+        with:
+          path: cache/solid-nextcloud
+          key: solid-nextcloud-docker-${{ github.sha }}
+
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -62,9 +79,9 @@ jobs:
 
       - name: Pull docker Images
         run: |
+          docker image load --input ./cache/solid-nextcloud/${{ github.sha }}.tar
           docker pull michielbdejong/nextcloud-cookie:${{ env.COOKIE_TAG }}
           docker pull ${{ matrix.test }}
-          docker pull ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}
           docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}
 
       - name: Start Docker Containers
@@ -78,8 +95,8 @@ jobs:
             "ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}"
 
           source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
-          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
+          startSolidNextcloud 'server' "solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
+          startSolidNextcloud 'thirdparty' "solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
 
           echo "COOKIE_server=${COOKIE_server}" >> "${GITHUB_ENV}"
           echo "COOKIE_thirdparty=${COOKIE_thirdparty}" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - cleanup/ci # @TODO: Remove this before merging to main
   pull_request:
     branches: [ main ]
 
@@ -20,14 +19,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # @TODO: Instead of building the docker image here, take a pre-build image and mount the code (only build when the Dockerfile changes)
+  # @TODO: Instead of building the docker image here, take a pre-build image and mount the code
+  #        (only build when the Dockerfile changes)
   build-docker-nextcloud:
     runs-on: ubuntu-latest
     steps:
-      - name: Creat docker tag from git reference
+      - name: Create docker tag from git reference
         # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
         run: |
-          echo "TAG=$(echo -n "${{ github.ref_name }}" | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" >> "${GITHUB_ENV}"
+          echo "TAG=$(echo -n "${{ github.ref_name }}" \
+            | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" \
+            >> "${GITHUB_ENV}"
 
       - uses: actions/cache@v3
         id: cache-solid-nextcloud-docker
@@ -68,10 +70,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Creat docker tag from git reference
+      - name: Create docker tag from git reference
         # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
         run: |
-          echo "TAG=$(echo -n "${{ github.ref_name }}" | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" >> "${GITHUB_ENV}"
+          echo "TAG=$(echo -n "${{ github.ref_name }}" \
+            | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" \
+            >> "${GITHUB_ENV}"
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,41 +3,101 @@
 # For more information see:
 # https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: CI
+name: Solid Test Suites
 
 on:
   push:
     branches:
-    - main
-    - cleanup/ci
+      - main
+      - cleanup/ci # @TODO: Remove this before merging to main
   pull_request:
     branches: [ main ]
 
 jobs:
-  build:
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
+  docker-build-pub-sub:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Solid test suite
-        shell: 'script -q -e -c "bash {0}"'
-        run: >-
-          source ./run-solid-test-suite.sh
-          && setup
-          && startPubSub
-          && startSolidNextcloud server
-          && startSolidNextcloud thirdparty
+      - name: Build Pub-Sub Docker image
+        run: |
+          docker build -t pubsub-server  https://github.com/pdsinterop/php-solid-pubsub-server.git#main
+          docker push ghcr.io/pdsinterop/solid-nextcloud:latest
 
-      - name: Run the Solid test suite
-        shell: 'script -q -e -c "bash {0}"'
-        run: >-
+  docker-build-nextcloud:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Solid-Nextcloud Docker image
+        run: |
+          docker build -t solid-nextcloud .
+          docker push ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+
+  run-tests:
+    needs:
+      - docker-build-nextcloud
+      - docker-build-pub-sub
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Solid webid-provider test suite
+        run: |
+          docker pull michielbdejong/nextcloud-cookie
+          docker pull solidtestsuite/webid-provider-tests:v2.1.0
+
+          docker network create testnet
+          docker run --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+
           source ./run-solid-test-suite.sh
-          && runTests webid-provider
-          && runTests solid-crud
-          && runTests web-access-control
+          startSolidNextcloud 'server' 'ghcr.io/pdsinterop/solid-nextcloud'
+          startSolidNextcloud 'thirdparty' 'ghcr.io/pdsinterop/solid-nextcloud'
+
+          docker run --rm --network=testnet \
+            --env COOKIE="$COOKIE_server" \
+            --env COOKIE_ALICE="$COOKIE_server" \
+            --env COOKIE_BOB="$COOKIE_thirdparty" \
+            --env-file ./env-vars-testers.list \
+            solidtestsuite/webid-provider-tests:v2.1.0
+
+      - name: Run Solid solid-crud test suite
+        run: |
+          docker pull michielbdejong/nextcloud-cookie
+          docker pull solidtestsuite/solid-crud-tests:v6.0.0
+
+          docker network create testnet
+          docker run --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+
+          source ./run-solid-test-suite.sh
+          startSolidNextcloud 'server' 'ghcr.io/pdsinterop/solid-nextcloud'
+          startSolidNextcloud 'thirdparty' 'ghcr.io/pdsinterop/solid-nextcloud'
+
+          docker run --rm --network=testnet \
+            --env COOKIE="$COOKIE_server" \
+            --env COOKIE_ALICE="$COOKIE_server" \
+            --env COOKIE_BOB="$COOKIE_thirdparty" \
+            --env-file ./env-vars-testers.list \
+            solidtestsuite/solid-crud-tests:v6.0.0
+
+      - name: Run Solid web-access-control test suite
+        run: |
+          docker pull michielbdejong/nextcloud-cookie
+          docker pull solidtestsuite/web-access-control-tests:v7.1.0
+
+          docker network create testnet
+          docker run --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+
+          source ./run-solid-test-suite.sh
+          startSolidNextcloud 'server' 'ghcr.io/pdsinterop/solid-nextcloud'
+          startSolidNextcloud 'thirdparty' 'ghcr.io/pdsinterop/solid-nextcloud'
+
+          docker run --rm --network=testnet \
+            --env COOKIE="$COOKIE_server" \
+            --env COOKIE_ALICE="$COOKIE_server" \
+            --env COOKIE_BOB="$COOKIE_thirdparty" \
+            --env-file ./env-vars-testers.list \
+            solidtestsuite/web-access-control-tests:v7.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # @FIXME: In stead of `latest` docker images need to be tagged with the MR/PR reference (or commit hash)
       - name: Build Solid-Nextcloud Docker image
         run: |
-          docker build -t "ghcr.io/pdsinterop/solid-nextcloud:latest" .
-          docker push "ghcr.io/pdsinterop/solid-nextcloud:latest"
+          docker build -t "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" .
+          docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}"
 
   solid-testsuite:
     strategy:
@@ -61,7 +60,7 @@ jobs:
         run: |
           docker pull michielbdejong/nextcloud-cookie
           docker pull ${{ matrix.test }}
-          docker pull ghcr.io/pdsinterop/solid-nextcloud:latest
+          docker pull ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}
           docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:latest
 
       - name: Start Docker Containers
@@ -70,8 +69,8 @@ jobs:
           docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
 
           source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
-          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
+          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
+          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
 
           echo "COOKIE_server=${COOKIE_server}" >> "${GITHUB_ENV}"
           echo "COOKIE_thirdparty=${COOKIE_thirdparty}" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,18 @@ jobs:
           docker network create testnet
           docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
 
-      - name: Run tests - ${{ matrix.test }}
-        run: |
           source ./run-solid-test-suite.sh
           startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
           startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
+
+          echo "COOKIE_server=${COOKIE_server}" >> "${GITHUB_ENV}"
+          echo "COOKIE_thirdparty=${COOKIE_thirdparty}" >> "${GITHUB_ENV}"
+
+      - name: Run tests - ${{ matrix.test }}
+        run: |
+          export COOKIE_server="${{ env.COOKIE_server }}"
+          export COOKIE_thirdparty="${{ env.COOKIE_thirdparty }}"
+
           docker run -i --rm --network=testnet \
             --name tester \
             --env COOKIE="$COOKIE_server" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,21 @@ jobs:
         os: [ ubuntu-latest ]
 
     steps:
-      - uses: actions/checkout@v2
-      # Run the Solid test-suite
+      - uses: actions/checkout@v3
+
+      - name: Setup Solid test suite
+        shell: 'script -q -e -c "bash {0}"'
+        run: >-
+          source ./run-solid-test-suite.sh
+          && setup
+          && startPubSub
+          && startSolidNextcloud server
+          && startSolidNextcloud thirdparty
+
       - name: Run the Solid test suite
         shell: 'script -q -e -c "bash {0}"'
-        run: |
-          bash ./run-solid-test-suite.sh
+        run: >-
+          source ./run-solid-test-suite.sh
+          && runTests webid-provider
+          && runTests solid-crud
+          && runTests web-access-control

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Build Solid-Nextcloud Docker image
         run: |
           docker build \
-            --tag "solid-nextcloud:${{ github.sha }}" \
-            --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" \
+            --tag "solid-nextcloud:${{ github.ref_name }}" \
+            --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ github.ref_name }}" \
           .
-          docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}"
+          docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ github.ref_name }}"
           mkdir -p cache/solid-nextcloud
-          docker image save solid-nextcloud:${{ github.sha }} --output ./cache/solid-nextcloud/${{ github.sha }}.tar
+          docker image save solid-nextcloud:${{ github.ref_name }} --output ./cache/solid-nextcloud/${{ github.sha }}.tar
 
   solid-testsuite:
     strategy:
@@ -95,8 +95,8 @@ jobs:
             "ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}"
 
           source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
-          startSolidNextcloud 'thirdparty' "solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}
+          startSolidNextcloud 'server' "solid-nextcloud:${{ github.ref_name }}" ${{ matrix.test }}
+          startSolidNextcloud 'thirdparty' "solid-nextcloud:${{ github.ref_name }}" ${{ matrix.test }}
 
           echo "COOKIE_server=${COOKIE_server}" >> "${GITHUB_ENV}"
           echo "COOKIE_thirdparty=${COOKIE_thirdparty}" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 ---
 name: Solid Test Suites
 
+env:
+  PUBSUB_TAG: latest@sha256:35166933e3d30bde801fd156bd2f21ebba9cdeca464ebd574c6be4cdb14d35cd
+  COOKIE_TAG: latest@sha256:c71a3947f97d96ce09823743182582e0d919738be0d4ef5c8c55a9c22c615b91
+
 on:
   push:
     branches:
@@ -58,15 +62,20 @@ jobs:
 
       - name: Pull docker Images
         run: |
-          docker pull michielbdejong/nextcloud-cookie
+          docker pull michielbdejong/nextcloud-cookie:${{ env.COOKIE_TAG }}
           docker pull ${{ matrix.test }}
           docker pull ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}
-          docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+          docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}
 
       - name: Start Docker Containers
         run: |
           docker network create testnet
-          docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
+          docker run \
+            --detach \
+            --interactive \
+            --name 'pubsub' \
+            --network=testnet \
+            "ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}"
 
           source ./run-solid-test-suite.sh
           startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:${{ github.sha }}" ${{ matrix.test }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
           docker build -t "ghcr.io/pdsinterop/solid-nextcloud:latest" .
           docker push "ghcr.io/pdsinterop/solid-nextcloud:latest"
 
-  run-tests:
+  # @TODO: Instead of duplicating this code 3 times, use a matrix?
+  test-webid-provider:
     needs:
       - docker-build-nextcloud
 
@@ -63,40 +64,70 @@ jobs:
             --env-file ./env-vars-testers.list \
             solidtestsuite/webid-provider-tests:v2.1.0
 
-#      - name: Run Solid solid-crud test suite
-#        run: |
-#          docker pull michielbdejong/nextcloud-cookie
-#          docker pull solidtestsuite/solid-crud-tests:v6.0.0
-#
-#          docker network create testnet
-#          docker run -i --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
-#
-#          source ./run-solid-test-suite.sh
-#          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-#          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-#
-#          docker run -i --rm --network=testnet \
-#            --env COOKIE="$COOKIE_server" \
-#            --env COOKIE_ALICE="$COOKIE_server" \
-#            --env COOKIE_BOB="$COOKIE_thirdparty" \
-#            --env-file ./env-vars-testers.list \
-#            solidtestsuite/solid-crud-tests:v6.0.0
-#
-#      - name: Run Solid web-access-control test suite
-#        run: |
-#          docker pull michielbdejong/nextcloud-cookie
-#          docker pull solidtestsuite/web-access-control-tests:v7.1.0
-#
-#          docker network create testnet
-#          docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
-#
-#          source ./run-solid-test-suite.sh
-#          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-#          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-#
-#          docker run -i --rm --network=testnet \
-#            --env COOKIE="$COOKIE_server" \
-#            --env COOKIE_ALICE="$COOKIE_server" \
-#            --env COOKIE_BOB="$COOKIE_thirdparty" \
-#            --env-file ./env-vars-testers.list \
-#            solidtestsuite/web-access-control-tests:v7.1.0
+  test-solid-crud:
+    needs:
+      - docker-build-nextcloud
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Solid solid-crud test suite
+        run: |
+          docker pull michielbdejong/nextcloud-cookie
+          docker pull solidtestsuite/solid-crud-tests:v6.0.0
+
+          docker network create testnet
+          docker run -i --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
+
+          source ./run-solid-test-suite.sh
+          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+
+          docker run -i --rm --network=testnet \
+            --env COOKIE="$COOKIE_server" \
+            --env COOKIE_ALICE="$COOKIE_server" \
+            --env COOKIE_BOB="$COOKIE_thirdparty" \
+            --env-file ./env-vars-testers.list \
+            solidtestsuite/solid-crud-tests:v6.0.0
+
+  test-web-access-control:
+    needs:
+      - docker-build-nextcloud
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Solid web-access-control test suite
+        run: |
+          docker pull michielbdejong/nextcloud-cookie
+          docker pull solidtestsuite/web-access-control-tests:v7.1.0
+
+          docker network create testnet
+          docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
+
+          source ./run-solid-test-suite.sh
+          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
+
+          docker run -i --rm --network=testnet \
+            --env COOKIE="$COOKIE_server" \
+            --env COOKIE_ALICE="$COOKIE_server" \
+            --env COOKIE_BOB="$COOKIE_thirdparty" \
+            --env-file ./env-vars-testers.list \
+            solidtestsuite/web-access-control-tests:v7.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,14 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # @TODO: Instead of building the docker image here, take a pre-build image and mount the code (only build when the Dockerfile changes)
   docker-build-nextcloud:
     runs-on: ubuntu-latest
     steps:
@@ -27,8 +34,15 @@ jobs:
           docker build -t "ghcr.io/pdsinterop/solid-nextcloud:latest" .
           docker push "ghcr.io/pdsinterop/solid-nextcloud:latest"
 
-  # @TODO: Instead of duplicating this code 3 times, use a matrix?
-  test-webid-provider:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - 'solidtestsuite/solid-crud-tests:v6.0.0'
+          - 'solidtestsuite/web-access-control-tests:v7.1.0'
+          - 'solidtestsuite/webid-provider-tests:v2.1.0'
+
     needs:
       - docker-build-nextcloud
 
@@ -46,7 +60,7 @@ jobs:
       - name: Run Solid webid-provider test suite
         run: |
           docker pull michielbdejong/nextcloud-cookie
-          docker pull solidtestsuite/webid-provider-tests:v2.1.0
+          docker pull ${{ matrix.test }}
           docker pull ghcr.io/pdsinterop/solid-nextcloud:latest
           docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:latest
 
@@ -62,72 +76,4 @@ jobs:
             --env COOKIE_ALICE="$COOKIE_server" \
             --env COOKIE_BOB="$COOKIE_thirdparty" \
             --env-file ./env-vars-testers.list \
-            solidtestsuite/webid-provider-tests:v2.1.0
-
-  test-solid-crud:
-    needs:
-      - docker-build-nextcloud
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Solid solid-crud test suite
-        run: |
-          docker pull michielbdejong/nextcloud-cookie
-          docker pull solidtestsuite/solid-crud-tests:v6.0.0
-
-          docker network create testnet
-          docker run -i --network=testnet -d --name pubsub ghcr.io/pdsinterop/php-solid-pubsub-server:latest
-
-          source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-
-          docker run -i --rm --network=testnet \
-            --env COOKIE="$COOKIE_server" \
-            --env COOKIE_ALICE="$COOKIE_server" \
-            --env COOKIE_BOB="$COOKIE_thirdparty" \
-            --env-file ./env-vars-testers.list \
-            solidtestsuite/solid-crud-tests:v6.0.0
-
-  test-web-access-control:
-    needs:
-      - docker-build-nextcloud
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Solid web-access-control test suite
-        run: |
-          docker pull michielbdejong/nextcloud-cookie
-          docker pull solidtestsuite/web-access-control-tests:v7.1.0
-
-          docker network create testnet
-          docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
-
-          source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-
-          docker run -i --rm --network=testnet \
-            --env COOKIE="$COOKIE_server" \
-            --env COOKIE_ALICE="$COOKIE_server" \
-            --env COOKIE_BOB="$COOKIE_thirdparty" \
-            --env-file ./env-vars-testers.list \
-            solidtestsuite/web-access-control-tests:v7.1.0
+            ${{ matrix.test }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: Solid Test Suites
 
 env:
+  # Docker Hub digest (i.e. hash) of the used Docker Images that do not have a version tag.
   PUBSUB_TAG: latest@sha256:35166933e3d30bde801fd156bd2f21ebba9cdeca464ebd574c6be4cdb14d35cd
   COOKIE_TAG: latest@sha256:c71a3947f97d96ce09823743182582e0d919738be0d4ef5c8c55a9c22c615b91
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - 'solidtestsuite/solid-crud-tests:v6.0.0'
+          - 'solidtestsuite/solid-crud-tests:v7.0.5'
           - 'solidtestsuite/web-access-control-tests:v7.1.0'
           - 'solidtestsuite/webid-provider-tests:v2.1.0'
 
@@ -75,6 +75,7 @@ jobs:
           startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
           startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
           docker run -i --rm --network=testnet \
+            --name tester \
             --env COOKIE="$COOKIE_server" \
             --env COOKIE_ALICE="$COOKIE_server" \
             --env COOKIE_BOB="$COOKIE_thirdparty" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    - cleanup/ci
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   # @TODO: Instead of building the docker image here, take a pre-build image and mount the code (only build when the Dockerfile changes)
-  docker-build-nextcloud:
+  build-docker-nextcloud:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
           docker build -t "ghcr.io/pdsinterop/solid-nextcloud:latest" .
           docker push "ghcr.io/pdsinterop/solid-nextcloud:latest"
 
-  tests:
+  solid-testsuite:
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,7 @@ jobs:
           - 'solidtestsuite/webid-provider-tests:v2.1.0'
 
     needs:
-      - docker-build-nextcloud
+      - build-docker-nextcloud
 
     runs-on: ubuntu-latest
 
@@ -57,20 +57,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Solid webid-provider test suite
+      - name: Pull docker Images
         run: |
           docker pull michielbdejong/nextcloud-cookie
           docker pull ${{ matrix.test }}
           docker pull ghcr.io/pdsinterop/solid-nextcloud:latest
           docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:latest
 
+      - name: Start Docker Containers
+        run: |
           docker network create testnet
           docker run -i --network=testnet -d --name 'pubsub' "ghcr.io/pdsinterop/php-solid-pubsub-server:latest"
 
+      - name: Run tests - ${{ matrix.test }}
+        run: |
           source ./run-solid-test-suite.sh
-          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest"
-
+          startSolidNextcloud 'server' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
+          startSolidNextcloud 'thirdparty' "ghcr.io/pdsinterop/solid-nextcloud:latest" ${{ matrix.test }}
           docker run -i --rm --network=testnet \
             --env COOKIE="$COOKIE_server" \
             --env COOKIE_ALICE="$COOKIE_server" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -yq \
       git \
       sudo \
       vim \
+      zip \
     && rm -rf /var/lib/apt/lists/* \
     && a2enmod ssl \
     && mkdir /tls \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
 FROM nextcloud:24.0.1
-COPY site.conf /etc/apache2/sites-enabled/000-default.conf
-RUN a2enmod ssl
-RUN mkdir /tls
-RUN openssl req -new -x509 -days 365 -nodes \
-  -out /tls/server.cert \
-  -keyout /tls/server.key \
-  -subj "/C=RO/ST=Bucharest/L=Bucharest/O=IT/CN=www.example.ro"
+
 RUN apt-get update && apt-get install -yq \
-  git \
-  vim \
-  sudo
-WORKDIR /install
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-ADD ./solid /usr/src/nextcloud/apps/solid
-# Run composer:
-WORKDIR /usr/src/nextcloud/apps/solid
-RUN ls
-RUN php /install/composer.phar update
-RUN php /install/composer.phar install --no-dev --prefer-dist
+      git \
+      sudo \
+      vim \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod ssl \
+    && mkdir /tls \
+    && openssl req -new -x509 -days 365 -nodes \
+      -keyout /tls/server.key \
+      -out /tls/server.cert \
+      -subj "/C=RO/ST=Bucharest/L=Bucharest/O=IT/CN=www.example.ro"
+
+COPY solid/ /usr/src/nextcloud/apps/solid
+COPY init.sh /
+COPY init-live.sh /
+COPY site.conf /etc/apache2/sites-enabled/000-default.conf
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+RUN composer install --working-dir=/usr/src/nextcloud/apps/solid --no-dev --prefer-dist \
+    && rm  /usr/local/bin/composer
+
 WORKDIR /var/www/html
-ADD init.sh /
-ADD init-live.sh /
 EXPOSE 443

--- a/run-solid-test-suite.sh
+++ b/run-solid-test-suite.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
 function setup {
@@ -13,9 +14,10 @@ function setup {
   docker pull solidtestsuite/web-access-control-tests:v7.1.0
   docker tag solidtestsuite/web-access-control-tests:v7.1.0 web-access-control-tests
 }
+
 function teardown {
-  docker stop `docker ps --filter network=testnet -q`
-  docker rm `docker ps --filter network=testnet -qa`
+  docker stop "$(docker ps --filter network=testnet -q)"
+  docker rm "$(docker ps --filter network=testnet -qa)"
   docker network remove testnet
 }
 
@@ -24,21 +26,21 @@ function startPubSub {
 }
 
 function startSolidNextcloud {
-  docker run -d --name $1 --network=testnet --env-file ./env-vars-$1.list solid-nextcloud
-  until docker run --rm --network=testnet solidtestsuite/webid-provider-tests curl -kI https://$1 2> /dev/null > /dev/null
+  docker run -d --name "$1" --network=testnet --env-file "./env-vars-$1.list solid-nextcloud"
+  until docker run --rm --network=testnet solidtestsuite/webid-provider-tests curl -kI "https://$1" 2> /dev/null > /dev/null
   do
-    echo Waiting for $1 to start, this can take up to a minute ...
+    echo Waiting for "$1" to start, this can take up to a minute ...
     docker ps -a
-    docker logs $1
+    docker logs "$1"
     sleep 1
   done
 
-  docker logs $1
-  echo Running init script for Nextcloud $1 ...
-  docker exec -u www-data -it -e SERVER_ROOT=https://$1 $1 sh /init.sh
-  docker exec -u root -it $1 service apache2 reload
-  echo Getting cookie for $1...
-  export COOKIE_$1="`docker run --cap-add=SYS_ADMIN --network=testnet --env-file ./env-vars-$1.list michielbdejong/nextcloud-cookie`"
+  docker logs "$1"
+  echo "Running init script for Nextcloud $1 ..."
+  docker exec -u www-data -it -e SERVER_ROOT="https://$1" "$1" sh /init.sh
+  docker exec -u root -it "$1" service apache2 reload
+  echo Getting cookie for "$1"...
+  export COOKIE_$1="$(docker run --cap-add=SYS_ADMIN --network=testnet --env-file "./env-vars-$1.list" michielbdejong/nextcloud-cookie)"
 }
 
 function runTests {
@@ -51,13 +53,26 @@ function runTests {
     --env-file ./env-vars-testers.list $1-tests
 }
 
-# ...
-teardown || true
-setup
-startPubSub
-startSolidNextcloud server
-startSolidNextcloud thirdparty
-runTests webid-provider
-runTests web-access-control
-runTests solid-crud
-teardown
+run_solid_test_suite() {
+    # ...
+    teardown || true
+    setup
+    startPubSub
+    startSolidNextcloud server
+    startSolidNextcloud thirdparty
+    runTests webid-provider
+    runTests web-access-control
+    runTests solid-crud
+    teardown
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+  run_solid_test_suite "${@}"
+else
+    export -f run_solid_test_suite
+    export -f runTests
+    export -f setup
+    export -f startPubSub
+    export -f startSolidNextcloud
+    export -f teardown
+fi

--- a/run-solid-test-suite.sh
+++ b/run-solid-test-suite.sh
@@ -3,16 +3,19 @@
 set -e
 
 function setup {
-  docker network create testnet
-  docker build -t solid-nextcloud .
   docker build -t pubsub-server  https://github.com/pdsinterop/php-solid-pubsub-server.git#main
+  docker build -t solid-nextcloud .
+
+  docker network create testnet
+
   docker pull michielbdejong/nextcloud-cookie
-  docker pull solidtestsuite/webid-provider-tests:v2.1.0
-  docker tag solidtestsuite/webid-provider-tests:v2.1.0 webid-provider-tests
   docker pull solidtestsuite/solid-crud-tests:v7.0.5
-  docker tag solidtestsuite/solid-crud-tests:v7.0.5 solid-crud-tests
   docker pull solidtestsuite/web-access-control-tests:v7.1.0
+  docker pull solidtestsuite/webid-provider-tests:v2.1.0
+
+  docker tag solidtestsuite/solid-crud-tests:v7.0.5 solid-crud-tests
   docker tag solidtestsuite/web-access-control-tests:v7.1.0 web-access-control-tests
+  docker tag solidtestsuite/webid-provider-tests:v2.1.0 webid-provider-tests
 }
 
 function teardown {
@@ -37,8 +40,8 @@ function startSolidNextcloud {
 
   docker logs "$1"
   echo "Running init script for Nextcloud $1 ..."
-  docker exec -u www-data -it -e SERVER_ROOT="https://$1" "$1" sh /init.sh
-  docker exec -u root -it "$1" service apache2 reload
+  docker exec -u www-data -i -e SERVER_ROOT="https://$1" "$1" sh /init.sh
+  docker exec -u root -i "$1" service apache2 reload
   echo Getting cookie for "$1"...
   export COOKIE_$1="$(docker run --cap-add=SYS_ADMIN --network=testnet --env-file "./env-vars-$1.list" michielbdejong/nextcloud-cookie)"
 }

--- a/run-solid-test-suite.sh
+++ b/run-solid-test-suite.sh
@@ -26,7 +26,7 @@ function startPubSub {
 }
 
 function startSolidNextcloud {
-  docker run -d --name "$1" --network=testnet --env-file "./env-vars-$1.list solid-nextcloud"
+  docker run -d --name "$1" --network=testnet --env-file "./env-vars-$1.list" "${2:-solid-nextcloud}"
   until docker run --rm --network=testnet solidtestsuite/webid-provider-tests curl -kI "https://$1" 2> /dev/null > /dev/null
   do
     echo Waiting for "$1" to start, this can take up to a minute ...
@@ -50,7 +50,8 @@ function runTests {
     --env COOKIE="$COOKIE_server" \
     --env COOKIE_ALICE="$COOKIE_server" \
     --env COOKIE_BOB="$COOKIE_thirdparty" \
-    --env-file ./env-vars-testers.list $1-tests
+    --env-file ./env-vars-testers.list \
+    "$1-tests"
 }
 
 run_solid_test_suite() {


### PR DESCRIPTION
Currently,  the GitHub Workflow that runs the Solid Test Suite calls `bash ./run-solid-test-suite.sh`.
That script then pulls and build various Docker images, spins them up and runs the tests (in the `solidtestsuite` containers) against the `pdsinterop` containers.

The major downside of this are:

- The docker images are created every time the workflow runs, regardless of whether they have actual changes
- The tests run sequentially, rather than in parallel
- All the output is present in a single "step", running into hundreds or thousands of lines, making it harder to zoom in to the actual problem

The main goals of this merge-request are to make the GitHub workflow run in parallel, and to make it easier to see what/why tests failed. These changes are also a starting point to make it easier to run other tools or tests against a running Nextcloud instance.

To achieve this goal, the steps from the script are reproduced in the workflow file. The _build_ has been separated into a separate job from the pull & run steps. Next, pulling the Docker images, starting the Docker containers, and running the test have been placed into separate jobs (so their output is also split into separate parts). Finally, the tests are run in a matrix (to reduce code-duplication and so that they are run in parallel).

Building the pub-sup image has been moved to its own repo (see https://github.com/pdsinterop/php-solid-pubsub-server/pull/3)


Further optimizations could be added in follow-up MRs. (For instance only building the Solid-Nextcloud Docker image when the Dockerfile and/or related files change or by only pulling the remote Docker images once and placing them in a cache to be used by subsequent steps).

Besides this, the `Dockerfile` `run-solid-test-suite.sh` files have also been cleanup somewhat. See their respective commits for details.
