### PR TITLE
Run the CI against multiple Nextcloud versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # For the latest version information see: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
+        # Versions before 22 are not tested as they run on PHP versions lower than 8.0
+        # Versions before 24 are not tested as they do not support `.well-known` entries
+        # Latest is not tested here, as that could cause failures unrelated to project changes
         nextcloud_version:
-          - 22
-          - 23
           - 24
           - 25
-          - latest
 
     steps:
       - name: Create docker tag from git reference
@@ -70,6 +71,7 @@ jobs:
           docker image save solid-nextcloud:${{ env.TAG }} --output ./cache/solid-nextcloud/${{ github.sha }}-${{ matrix.nextcloud_version }}.tar
 
   solid-testsuite:
+    timeout-minutes: 30
     needs:
       - build-docker-nextcloud
 
@@ -78,21 +80,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Versions older than 22 are not tested as they run on PHP versions lower than 8.0
         nextcloud_version:
-          - 22
-          - 23
           - 24
           - 25
-          - latest
         test:
           - 'solidtestsuite/solid-crud-tests:v7.0.5'
           - 'solidtestsuite/web-access-control-tests:v7.1.0'
           - 'solidtestsuite/webid-provider-tests:v2.1.0'
 
-    # For the latest version information see: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
-    # Allow EOL or non-stable versions of Nextcloud to fail the test-suite
-    continue-on-error: ${{ contains(fromJson('[23, 24, 25]'), matrix.nextcloud_version) == false }}
+    # Prevent EOL or non-stable versions of Nextcloud to fail the test-suite
+    continue-on-error: ${{ contains(fromJson('[24, 25]'), matrix.nextcloud_version) == false }}
 
     steps:
       - name: Create docker tag from git reference

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         id: cache-solid-nextcloud-docker
         with:
           path: cache/solid-nextcloud
-          key: solid-nextcloud-docker-${{ github.sha }}
+          key: solid-nextcloud-docker-${{ matrix.nextcloud_version }}-${{ github.sha }}
 
       - uses: actions/checkout@v3
 
@@ -108,7 +108,7 @@ jobs:
         id: cache-solid-nextcloud-docker
         with:
           path: cache/solid-nextcloud
-          key: solid-nextcloud-docker-${{ github.sha }}
+          key: solid-nextcloud-docker-${{ matrix.nextcloud_version }}-${{ github.sha }}
 
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-      - ci/multiple-nc-versions  # @TODO: Remove this before merging to main
   pull_request:
     branches: [ main ]
   # Allow manually triggering the workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,11 @@ on:
   push:
     branches:
       - main
+      - ci/multiple-nc-versions  # @TODO: Remove this before merging to main
   pull_request:
     branches: [ main ]
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
@@ -20,15 +23,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # @TODO: Instead of building the docker image here, take a pre-build image and mount the code
-  #        (only build when the Dockerfile changes)
+  # @TODO: Instead of building the docker image here, take a pre-build image and mount the code?
+  #        (only build when the Dockerfile changes) Or only push when tagged/main?
   build-docker-nextcloud:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nextcloud_version:
+          - 22
+          - 23
+          - 24
+          - 25
+          - latest
+
     steps:
       - name: Create docker tag from git reference
         # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
         run: |
-          echo "TAG=$(echo -n "${{ github.ref_name }}" \
+          echo "TAG=$(echo -n "${{ github.ref_name }}-${{ matrix.nextcloud_version }}" \
             | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" \
             >> "${GITHUB_ENV}"
 
@@ -46,35 +58,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Solid-Nextcloud Docker image
+      - name: Build Solid-Nextcloud Docker image from NC-${{ matrix.nextcloud_version }}
         run: |
           docker build \
             --tag "solid-nextcloud:${{ env.TAG }}" \
             --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ env.TAG }}" \
+            --build-arg 'NEXTCLOUD_VERSION=${{ matrix.nextcloud_version }}' \
           .
           docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ env.TAG }}"
           mkdir -p cache/solid-nextcloud
-          docker image save solid-nextcloud:${{ env.TAG }} --output ./cache/solid-nextcloud/${{ github.sha }}.tar
+          docker image save solid-nextcloud:${{ env.TAG }} --output ./cache/solid-nextcloud/${{ github.sha }}-${{ matrix.nextcloud_version }}.tar
 
   solid-testsuite:
-    strategy:
-      fail-fast: false
-      matrix:
-        test:
-          - 'solidtestsuite/solid-crud-tests:v7.0.5'
-          - 'solidtestsuite/web-access-control-tests:v7.1.0'
-          - 'solidtestsuite/webid-provider-tests:v2.1.0'
-
     needs:
       - build-docker-nextcloud
 
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # Versions older than 22 are not tested as they run on PHP versions lower than 8.0
+        nextcloud_version:
+          - 22
+          - 23
+          - 24
+          - 25
+          - latest
+        test:
+          - 'solidtestsuite/solid-crud-tests:v7.0.5'
+          - 'solidtestsuite/web-access-control-tests:v7.1.0'
+          - 'solidtestsuite/webid-provider-tests:v2.1.0'
+
+    # For the latest version information see: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
+    # Allow EOL or non-stable versions of Nextcloud to fail the test-suite
+    continue-on-error: ${{ contains(fromJson('[23, 24, 25]'), matrix.nextcloud_version) == false }}
+
     steps:
       - name: Create docker tag from git reference
         # A tag name may only contain lower- and uppercase letters, digits, underscores, periods and dashes.
         run: |
-          echo "TAG=$(echo -n "${{ github.ref_name }}" \
+          echo "TAG=$(echo -n "${{ github.ref_name }}-${{ matrix.nextcloud_version }}" \
             | tr --complement --squeeze-repeats '[:alnum:]._-' '_')" \
             >> "${GITHUB_ENV}"
 
@@ -92,9 +116,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # FIXME: The `docker pull` should be moved to a previous step and cached
       - name: Pull docker Images
         run: |
-          docker image load --input ./cache/solid-nextcloud/${{ github.sha }}.tar
+          docker image load --input ./cache/solid-nextcloud/${{ github.sha }}-${{ matrix.nextcloud_version }}.tar
           docker pull michielbdejong/nextcloud-cookie:${{ env.COOKIE_TAG }}
           docker pull ${{ matrix.test }}
           docker pull ghcr.io/pdsinterop/php-solid-pubsub-server:${{ env.PUBSUB_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM nextcloud:24.0.1
+ARG NEXTCLOUD_VERSION
+FROM nextcloud:${NEXTCLOUD_VERSION}
 
 RUN apt-get update && apt-get install -yq \
       git \

--- a/solid/appinfo/info.xml
+++ b/solid/appinfo/info.xml
@@ -18,7 +18,7 @@ IMPORTANT: See https://github.com/pdsinterop/solid-nextcloud/blob/main/INSTALL.m
     <category>integration</category>
     <bugs>https://github.com/pdsinterop/solid-nextcloud/issues</bugs>
     <dependencies>
-        <nextcloud min-version="24" max-version="24"/>
+        <nextcloud min-version="24" max-version="25"/>
     </dependencies>
     <settings>
         <admin>OCASolidSettings</admin>


### PR DESCRIPTION
This MR adds further improvements to the CI build step which runs the Solid testsuites against Solid Nextcloud. This includes preperations for supporting NC25.