### PR TITLE
Remove unneeded reference to INSTALL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 A plugin to make Nextcloud compatible with Solid.
 
 You can download it via the Nextcloud app store: https://apps.nextcloud.com/apps/solid
-IMPORTANT: Follow the [install instructions!](https://github.com/pdsinterop/solid-nextcloud/blob/main/INSTALL.md).
 
 ## Development install
 Clone https://github.com/pdsinterop/test-suites, cd into it, and run:

--- a/solid/README.md
+++ b/solid/README.md
@@ -1,6 +1,5 @@
 # Solid 
 Place this app in **nextcloud/apps/**
-IMPORTANT: Follow the [additional install instructions!](https://github.com/pdsinterop/solid-nextcloud/blob/main/INSTALL.md).
 
 ## Building the app
 

--- a/solid/appinfo/info.xml
+++ b/solid/appinfo/info.xml
@@ -9,7 +9,7 @@
 This app gives every user on the server a Solid pod storage space and a corresponding WebID URL.
 It supports the webid-oidc-dpop-pkce login flow to connect to a Solid App with your Nextcloud User.
 When you do this, the Solid App can store data in your Nextcloud account through the Solid protocol.
-IMPORTANT: See [INSTALL.md](https://github.com/pdsinterop/solid-nextcloud/blob/main/INSTALL.md) for additional install instructions!
+
 ]]></description>
     <version>0.8.1</version>
     <licence>agpl</licence>


### PR DESCRIPTION
Since the plugin install process has become more stable during the last versions, the explicit warning to read INSTALL.md is no longer needed, other than for manual install.