### PR TITLE
added data-simply-storage=none

### DIFF
--- a/solid/templates/applauncher/index.php
+++ b/solid/templates/applauncher/index.php
@@ -15,7 +15,8 @@
 <script type="application/json" id="storageUrl">
     <?php echo($_['storageUrl']); ?>
 </script>
-<script data-simply-sorage="none"></script>
+<!-- the following template is used to convince simply-edit to use this for settings -->
+<template src="simply-edit.js" data-api-key="nextcloud" data-simply-sorage="none"></template>
 <main class="solid-container solid-launcher" data-simply-field="page" data-simply-content="template">
 	<template data-simply-template="Launcher">
 		<ul data-simply-list="apps" class="solid-apps">

--- a/solid/templates/applauncher/index.php
+++ b/solid/templates/applauncher/index.php
@@ -15,6 +15,7 @@
 <script type="application/json" id="storageUrl">
     <?php echo($_['storageUrl']); ?>
 </script>
+<script data-simply-sorage="none"></script>
 <main class="solid-container solid-launcher" data-simply-field="page" data-simply-content="template">
 	<template data-simply-template="Launcher">
 		<ul data-simply-list="apps" class="solid-apps">


### PR DESCRIPTION
Issue:
On a vanilla install I have an error message in the console:
|GET https://nextcloud.myplace.synology.me/data/data.json 404 (Not Found) simply-edit.js?v=1256fc60-0:3443 

Solution:
added data-simply-storage="none" to the index.php. simply-edit.js will use it at line 2547.

Note:
ATTENTION: if ariadne github or gitlab storage was needed, this probably breaks that. I don't know if this is important.