### PR TITLE
Remove dead-end endpoint.

### DIFF
--- a/solid/appinfo/routes.php
+++ b/solid/appinfo/routes.php
@@ -13,7 +13,6 @@ return [
         ['name' => 'page#approval', 'url' => '/sharing/{clientId}', 'verb' => 'GET'],
         ['name' => 'page#handleRevoke', 'url' => '/revoke/{clientId}', 'verb' => 'GET'],
         ['name' => 'page#handleApproval', 'url' => '/sharing/{clientId}', 'verb' => 'POST'],
-        ['name' => 'page#dataJson', 'url' => '/@{userId}/data.json', 'verb' => 'GET' ],
         ['name' => 'page#customscheme', 'url' => '/customscheme', 'verb' => 'GET'],
 		
         ['name' => 'server#cors', 'url' => '/{path}', 'verb' => 'OPTIONS', 'requirements' => array('path' => '.+') ],


### PR DESCRIPTION
There is no `PageController::dataJson()` function, so the `/@{userId}/data.json` route currently doesn't go anywhere.

This MR removes the route. Is this correct? Or should a function be created?

Resolution of NF-008

