### PR TITLE
use main docker images

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -95,7 +95,7 @@ jobs:
             --rm \
             --volume="./solid:/var/www/html/apps/solid" \
             --workdir=/var/www/html/apps/solid \
-            ghcr.io/pdsinterop/solid-nextcloud:179_merge-${{ matrix.nextcloud_version }} \
+            ghcr.io/pdsinterop/solid-nextcloud:main-${{ matrix.nextcloud_version }} \
             bin/phpunit --configuration phpunit.xml
 
   # 03.quality.php.scan.dependencies-vulnerabilities.yml

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,9 +94,11 @@ jobs:
             --env 'XDEBUG_MODE=coverage' \
             --rm \
             --volume="./solid:/var/www/html/apps/solid" \
-            --workdir=/var/www/html/apps/solid \
             ghcr.io/pdsinterop/solid-nextcloud:main-${{ matrix.nextcloud_version }} \
-            bin/phpunit --configuration phpunit.xml
+            bash -c 'NEXTCLOUD_UPDATE=1 /entrypoint.sh "echo" \
+              && sudo -u www-data bash /init.sh \
+              && cd /var/www/html/apps/solid \
+              && bin/phpunit --configuration phpunit.xml'
 
   # 03.quality.php.scan.dependencies-vulnerabilities.yml
   scan-dependencies-vulnerabilities:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,7 +94,7 @@ jobs:
             --env 'XDEBUG_MODE=coverage' \
             --rm \
             --volume="./solid:/var/www/html/apps/solid" \
-            ghcr.io/pdsinterop/solid-nextcloud:main-${{ matrix.nextcloud_version }} \
+            ghcr.io/${{ github.repository }}:main-${{ matrix.nextcloud_version }} \
             bash -c 'NEXTCLOUD_UPDATE=1 /entrypoint.sh "echo" \
               && sudo -u www-data bash /init.sh \
               && cd /var/www/html/apps/solid \

--- a/.github/workflows/solid-tests-suites.yml
+++ b/.github/workflows/solid-tests-suites.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           docker build \
             --tag "solid-nextcloud:${{ env.TAG }}" \
-            --tag "ghcr.io/pdsinterop/solid-nextcloud:${{ env.TAG }}" \
+            --tag "ghcr.io/${{ github.repository }}:${{ env.TAG }}" \
             --build-arg 'NEXTCLOUD_VERSION=${{ matrix.nextcloud_version }}' \
           .
-          docker push "ghcr.io/pdsinterop/solid-nextcloud:${{ env.TAG }}"
+          docker push "ghcr.io/${{ github.repository }}:${{ env.TAG }}"
           mkdir -p cache/solid-nextcloud
           docker image save solid-nextcloud:${{ env.TAG }} --output ./cache/solid-nextcloud/${{ github.sha }}-${{ matrix.nextcloud_version }}.tar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ COPY site.conf /etc/apache2/sites-enabled/000-default.conf
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN composer install --working-dir=/usr/src/nextcloud/apps/solid --no-dev --prefer-dist \
-    && rm  /usr/local/bin/composer
+RUN composer install --working-dir=/usr/src/nextcloud/apps/solid --prefer-dist \
+    && rm /usr/local/bin/composer
 
 WORKDIR /var/www/html
 EXPOSE 443


### PR DESCRIPTION
This lets phpunit run using the docker images from 'main' instead of the PR branch 179.

Fixes https://github.com/pdsinterop/solid-nextcloud/issues/196