### PR TITLE
Fix incorrect HTTP status code for missing redirect URIs

### DIFF
--- a/solid/lib/Controller/ServerController.php
+++ b/solid/lib/Controller/ServerController.php
@@ -348,8 +348,8 @@ class ServerController extends Controller
 	public function register() {
 		$clientData = file_get_contents('php://input');
 		$clientData = json_decode($clientData, true);
-		if (!$clientData['redirect_uris']) {
-			return new JSONResponse("Missing redirect URIs");
+		if (! isset($clientData['redirect_uris'])) {
+			return new JSONResponse("Missing redirect URIs", Http::STATUS_BAD_REQUEST);
 		}
 		$clientData['client_id_issued_at'] = time();
 		$parsedOrigin = parse_url($clientData['redirect_uris'][0]);


### PR DESCRIPTION
The client registration URL returned a 200 instead of a 400 on error. 
The line of code that added a 400 header was lost in a set of commits/merges.
This MR fixes that.

@poef This is the incorrect response we discussed