### PR TITLE
Update cookies docker hash

### DIFF
--- a/.github/workflows/solid-tests-suites.yml
+++ b/.github/workflows/solid-tests-suites.yml
@@ -4,7 +4,7 @@ name: Solid Test Suites
 env:
   # Docker Hub digest (i.e. hash) of the used Docker Images that do not have a version tag.
   PUBSUB_TAG: latest@sha256:b73a2a5c98d2005bb667dfc69d1c859d704366024298b9caa24ea2e182c456c2
-  COOKIE_TAG: latest@sha256:c71a3947f97d96ce09823743182582e0d919738be0d4ef5c8c55a9c22c615b91
+  COOKIE_TAG: latest@sha256:b2815496a1291a8f0f8bf2524c42d6000a4a1d6a202b319fe01e1afacf1cec7d
 
 on:
   push:

--- a/run-solid-test-suite.sh
+++ b/run-solid-test-suite.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+: "${COOKIE_TAG:=latest@sha256:b2815496a1291a8f0f8bf2524c42d6000a4a1d6a202b319fe01e1afacf1cec7d}"
+
 # Note that .github/workflows/solid-tests-suites.yml does not use this, this function is just for manual runs of this script.
 # You can pick different values for the NEXTCLOUD_VERSION build arg, as required:
 function setup {
@@ -10,7 +12,7 @@ function setup {
 
   docker network create testnet
 
-  docker pull michielbdejong/nextcloud-cookie
+  docker pull "michielbdejong/nextcloud-cookie:${COOKIE_TAG}"
   docker pull solidtestsuite/solid-crud-tests:v7.0.5
   docker pull solidtestsuite/web-access-control-tests:v7.1.0
   docker pull solidtestsuite/webid-provider-tests:v2.1.1
@@ -46,7 +48,12 @@ function startSolidNextcloud {
   docker exec -u www-data -i -e SERVER_ROOT="https://$1" "$1" sh /init.sh
   docker exec -u root -i "$1" service apache2 reload
   echo Getting cookie for "$1"...
-  export COOKIE_$1="$(docker run --cap-add=SYS_ADMIN --network=testnet --env-file "./env-vars-$1.list" michielbdejong/nextcloud-cookie)"
+  export COOKIE_$1="$(docker run \
+        --cap-add=SYS_ADMIN \
+        --network=testnet \
+        --env-file "./env-vars-$1.list" \
+        "michielbdejong/nextcloud-cookie:${COOKIE_TAG}"
+    )"
 }
 
 function runTests {


### PR DESCRIPTION
Looking into the logs of the `solid-tests-suites.yml` run, I noticed that `michielbdejong/nextcloud-cookie` was pulled twice. Not pulling the image again should save at least 30 seconds of CI runtime.

The cause was a combination of two things.

The first is that `run-solid-test-suite.sh` does a docker pull of `michielbdejong/nextcloud-cookie` without specifying a version. This defaults to `latest`.

The second is that the hash in `COOKIE_TAG` was not updated to the newer image.

This MR updates the hash to the newer image and changes the script to also use a hash, to resolve both issues.