### PR TITLE
Fix ServerController::logout() method

### DIFF
--- a/solid/lib/Controller/ServerController.php
+++ b/solid/lib/Controller/ServerController.php
@@ -3,6 +3,7 @@ namespace OCA\Solid\Controller;
 
 use OCA\Solid\DpopFactoryTrait;
 use OCA\Solid\ServerConfig;
+use OCA\Solid\Service\UserService;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -47,6 +48,8 @@ class ServerController extends Controller
 	/* @var \Pdsinterop\Solid\Auth\TokenGenerator */
 	private $tokenGenerator;
 
+	private UserService $userService;
+
 	public function __construct(
 		$AppName,
 		IRequest $request,
@@ -55,7 +58,7 @@ class ServerController extends Controller
 		IURLGenerator $urlGenerator,
 		$userId,
 		IConfig $config,
-		\OCA\Solid\Service\UserService $UserService,
+		UserService $userService,
 		IDBConnection $connection,
 	) {
 		parent::__construct($AppName, $request);
@@ -66,6 +69,7 @@ class ServerController extends Controller
 		$this->request     = $request;
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
+		$this->userService = $userService;
 
 		$this->setJtiStorage($connection);
 

--- a/solid/tests/Unit/Controller/ServerControllerTest.php
+++ b/solid/tests/Unit/Controller/ServerControllerTest.php
@@ -450,6 +450,29 @@ class ServerControllerTest extends TestCase
 		$this->assertEquals($expected, $actual);
 	}
 
+	/**
+	 * @testdox ServerController should return an OK when asked to logout
+	 *
+	 * @covers ::logout
+	 */
+	public function testLogout() {
+		$parameters = $this->createMockConstructorParameters();
+		$index = self::provideConstructorParameterIndex();
+		$mockUserService = $parameters[$index['userService'][0]];
+
+		$mockUserService->expects($this->once())
+			->method('logout')
+			->willReturn(null)
+		;
+
+		$controller = new ServerController(...array_values($parameters));
+
+		$actual = $controller->logout();
+		$expected = new JSONResponse('ok', Http::STATUS_OK);
+
+		$this->assertEquals($expected, $actual);
+	}
+
 	////////////////////////////// MOCKS AND STUBS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 	public function createMockConfig($clientData): IConfig|MockObject


### PR DESCRIPTION
The `UserService` was passed to the class, and called in the `logout` method, but the `UserService` object was not set in the constructor.

This MR fixes that.